### PR TITLE
Zms 598

### DIFF
--- a/src/com/zimbra/webClient/servlet/ServiceServlet.java
+++ b/src/com/zimbra/webClient/servlet/ServiceServlet.java
@@ -229,7 +229,6 @@ public class ServiceServlet extends HttpServlet {
         Server server = Provisioning.getInstance().getLocalServer();
         ZimbraSoapContext zsc = new ZimbraSoapContext(at, at.getAccountId(), SoapProtocol.SoapJS, SoapProtocol.SoapJS);
         AdminAccessControl aac = AdminAccessControl.getAdminAccessControl(zsc);
-        ZimbraLog.webclient.debug(String.format("Checking %s on %s using %s. Account %s", permission.getName(), server.getName(), aac.getClass().getSimpleName(), zsc.getAuthToken().isDelegatedAdmin() ? "delegated" : "not delegated"));
         aac.checkRight(server, permission);
     }
 

--- a/src/com/zimbra/webClient/servlet/ServiceServlet.java
+++ b/src/com/zimbra/webClient/servlet/ServiceServlet.java
@@ -124,8 +124,9 @@ public class ServiceServlet extends HttpServlet {
                 } else if ("/publiclogin".equals(path)) {
                     //this operation loads a JSP with login form for public login.
                     doPublicLoginProv(req, resp);
-                } else if ("/flushall".equals(path)) {
-                    //only automated tests need to flush all cache in /zimbra app
+                } else if ("/flushacl".equals(path)) {
+                    //only automated tests need to flush ACL cache in /zimbra app.
+                    //this call invalidates all LDAP entry caches where the ACL is cached.
                     if(authToken.isAdmin()) {
                         PermissionCache.invalidateAllCache();
                     } else {


### PR DESCRIPTION
- Avoid throwing NPEs if auth token is missing or empty
- Add ability for global admin to flush ACL cache. Currently, this is used only by automated tests to allow /zimbra web app to verify rights of newly created admin accounts
- return BAD_REQUEST for invalid zimlet names and bad zimlet archives