### PR TITLE
ZCS-913- Universal UI: Standard modal style changes

### DIFF
--- a/WebRoot/js/ajax/dwt/widgets/DwtDialog.js
+++ b/WebRoot/js/ajax/dwt/widgets/DwtDialog.js
@@ -73,6 +73,11 @@ DwtDialog = function(params) {
 		standardButtons = [standardButtons];
 	}
 
+	//sort buttons so that they are based on their position in order
+	if(AjxUtil.isArray(standardButtons)) {
+		standardButtons.sort();
+	}
+	
 	// assemble the list of button IDs, and the list of button descriptors
 	this._buttonList = [];
 	var buttonOrder = {};
@@ -127,6 +132,10 @@ DwtDialog = function(params) {
 	for (var i = 0; i < this._buttonList.length; i++) {
 		var buttonId = this._buttonList[i];
 		var b = this._button[buttonId] = new DwtButton({parent:this,id:this._htmlElId+"_button"+buttonId});
+		b.addClassName('ZDialogButton');
+		if(buttonId == DwtDialog.OK_BUTTON || buttonId == DwtDialog.YES_BUTTON) {
+			b.addClassName('ZPrimaryButton');
+		}
 		b.setText(this._buttonDesc[buttonId].label);
 		b.buttonId = buttonId;
 		b.addSelectionListener(new AjxListener(this, this._buttonListener));

--- a/WebRoot/js/ajax/dwt/widgets/DwtMessageDialog.js
+++ b/WebRoot/js/ajax/dwt/widgets/DwtMessageDialog.js
@@ -109,9 +109,6 @@ DwtMessageDialog.TITLE[DwtMessageDialog.WARNING_STYLE] = AjxMsg.warningMsg;
 DwtMessageDialog.TITLE[DwtMessageDialog.PLAIN_STYLE] = AjxMsg.infoMsg;
 
 DwtMessageDialog.ICON = {};
-DwtMessageDialog.ICON[DwtMessageDialog.CRITICAL_STYLE] = "Critical_32";
-DwtMessageDialog.ICON[DwtMessageDialog.INFO_STYLE] = "Information_32";
-DwtMessageDialog.ICON[DwtMessageDialog.WARNING_STYLE] = "Warning_32";
 
 DwtMessageDialog.HELP_BUTTON = "Help";
 // Public methods


### PR DESCRIPTION
Changes:
* DwtDialog.js:
  * Sorted `standard` buttons, so that they displays according to their position
  * Added custom class `ZDialogButton` to all action buttons in dialog and `ZPrimaryButton` to mail action button in dialog
* DwtMessageDialog.js:
  * Removed status icons.