### PR TITLE
ZCS-1017 Universal UI : Update DwtButton::_toggleHoverClass() to update the svg dom markup.

### DIFF
--- a/WebRoot/js/ajax/core/AjxImg.js
+++ b/WebRoot/js/ajax/core/AjxImg.js
@@ -78,11 +78,10 @@ function(parentEl, imageName, useParentEl, _disabled, classes, altText) {
 
     var className = AjxImg.getClassForImage(imageName, _disabled);
     if (useParentEl ) {
-        // @TODO no support for vector image here, is this used?
         DBG.println(AjxDebug.IMAGES, "No support for vector image when useParentEl is true");
-
         classes.push(className);
         parentEl.className = classes.join(" ");
+        imageData.v && (parentEl.innerHTML = AjxImg.createSVGTag(imageData, className));
         return;
     }
 

--- a/WebRoot/js/ajax/dwt/widgets/DwtButton.js
+++ b/WebRoot/js/ajax/dwt/widgets/DwtButton.js
@@ -808,7 +808,7 @@ function(show, direction) {
 	var iconEl = this._getIconEl(direction);
 	if (iconEl) {  //add a null check so buttons with no icon elements don't break the app.
 		var info = show ? this._hoverImageInfo[direction] : this.__imageInfo[direction];
-		iconEl.firstChild.className = AjxImg.getClassForImage(info);
+		AjxImg.setImage(iconEl.firstChild, info, true );
 	}
 };
 


### PR DESCRIPTION
ZCS-1017 Universal UI : Update DwtButton::_toggleHoverClass() to update the svg dom markup.

Changeset:

1. AjxImg.js : Updating AjxImg::setImage()  to update the svg markup if useParentEl is true.
2. DwtButton.js: Updating DwtButton::_toggleHoverClass() to update the class as well as svg markup if the image is vector. (handled by AjxImg::setImage() ).