### PR TITLE
Apply DwtControl.SUB_MENU_ACTIVE class only to DwtButton component.

### DIFF
--- a/WebRoot/js/ajax/dwt/widgets/DwtMenu.js
+++ b/WebRoot/js/ajax/dwt/widgets/DwtMenu.js
@@ -1156,7 +1156,7 @@ function(x, y, kbGenerated) {
 		DwtMenu._activeMenuUp = true;
 	}
 
-	this.parent && this.parent.addClassName && this.parent.addClassName(DwtControl.SUB_MENU_ACTIVE);
+	this.parent && !(this.parent instanceof DwtShell) && this.parent.addClassName && this.parent.addClassName(DwtControl.SUB_MENU_ACTIVE);
 
 	DwtMenu._activeMenuIds.add(this._htmlElId, null, true);
 	DwtMenu._activeMenuIds.sort();	


### PR DESCRIPTION
Description:

DwtControl.SUB_MENU_ACTIVE class is applied to the parent component when one of its submenu is made visible. There are some cases when Menu is attached directly to shell or some other components.
Ex: Right click a addrBubble.

Submenu active class not to be applied in this case to the shell.
With this change this class would only be applied to DwtButton component if a submenu is open .