### PR TITLE
ZCS-1032 Universal UI: Mini Calendar prev/next month buttons changing Years not the months.

### DIFF
--- a/WebRoot/js/ajax/dwt/widgets/DwtCalendar.js
+++ b/WebRoot/js/ajax/dwt/widgets/DwtCalendar.js
@@ -1007,7 +1007,7 @@ function(ev) {
 		return;
 	} else if (target.id.charAt(0) == 'b') {
 		var img;
-		if (target.firstChild == null) {
+		if (target.firstChild == null || target.firstChild instanceof SVGElement) {
 			img = target;
 			AjxImg.getParentElement(target).className = DwtCalendar._BUTTON_HOVERED_CLASS;
 		} else {
@@ -1032,7 +1032,7 @@ function(ev) {
 	} else if (target.id.charAt(0) == 'b') {
 		var img;
 		target.className = DwtCalendar._BUTTON_CLASS;
-		if (target.firstChild == null) {
+		if (target.firstChild == null || target.firstChild instanceof SVGElement) {
 			img = target;
 			AjxImg.getParentElement(target).className = DwtCalendar._BUTTON_CLASS;
 		} else {
@@ -1053,7 +1053,7 @@ function(ev) {
 			target.className = DwtCalendar._TITLE_ACTIVE_CLASS;
 		} else if (target.id.charAt(0) == 'b') {
 			var img;
-			if (target.firstChild == null) {
+			if (target.firstChild == null || target.firstChild instanceof SVGElement) {
 				img = target;
 				AjxImg.getParentElement(target).className = DwtCalendar._BUTTON_ACTIVE_CLASS;
 			} else {
@@ -1084,7 +1084,7 @@ function(ev) {
 			this._setClassName(target, DwtCalendar._HOVERED);
 		} else if (target.id.charAt(0) == 'b') {
 			var img;
-			if (target.firstChild == null) {
+			if (target.firstChild == null || target.firstChild instanceof SVGElement) {
 				img = target;
 				AjxImg.getParentElement(target).className = DwtCalendar._BUTTON_HOVERED_CLASS;
 			} else {


### PR DESCRIPTION
ZCS-1032
Universal UI: Mini Calendar prev/next month buttons changing Years not the months.

Issue: event.target getting passed as the SVGElement which used to be a div before causing hover/active classes to be applied on incorrect element and causing UI to break.

Fix: Added condition check for checking if the event.target is coming as SVGElement to handle it that way . (It is also possible that the event.target comes to be parent of svg element which should work fine.)

Change set:
1. DwtCalendar.js:   Adding condition to handle SVGElement in event.target .