### PR TITLE
ZCS-1510 AjxMsg.properties and I18nMsg.properties files are duplicated between zm-web-client and zm-ajax

### DIFF
--- a/WebRoot/messages/AjxMsg.properties
+++ b/WebRoot/messages/AjxMsg.properties
@@ -95,6 +95,7 @@ midnight = Midnight
 noon = Noon
 
 cancel = Cancel
+close = Close
 detail = Detail
 dismiss = Dismiss
 no = No


### PR DESCRIPTION
Issue: AjxMsg.properties and I18nMsg.properties files are duplicated in zm-ajax and zm-web-client repos
Fix: remove duplicated files from zm-web-client repo and merged changes which are committed to zm-web-client repo to zm-ajax repo

in zm-web-client repo on 6th Sep 2016, commit 71836a6d8c7976c2f78500ca5ac399673c14e67c was done to add close string, but as we have removed those files from zm-web-client repo and moved to zm-ajax repo so this commit reapplies changes of the older commit