### PR TITLE
ZCS-1315 Fix HTML client broken image issue due to change in universal-ui

### DIFF
--- a/WebRoot/js/ajax/core/AjxImg.js
+++ b/WebRoot/js/ajax/core/AjxImg.js
@@ -76,12 +76,12 @@ function(parentEl, imageName, useParentEl, _disabled, classes, altText) {
         return;
     }
 
-    var className = AjxImg.getClassForImage(imageName, _disabled);
-    if (useParentEl ) {
+    var className = AjxImg.getClassForImage(imageName + (imageData.v ? '-svg' : ''), _disabled);
+    if (useParentEl) {
         DBG.println(AjxDebug.IMAGES, "No support for vector image when useParentEl is true");
         classes.push(className);
         parentEl.className = classes.join(" ");
-        imageData.v && (parentEl.innerHTML = AjxImg.createSVGTag(imageData, className));
+        imageData.v && (parentEl.innerHTML = AjxImg.createSVGTag(imageData));
         return;
     }
 
@@ -121,7 +121,7 @@ function(parentEl, imageName, useParentEl, _disabled, classes, altText) {
 
         // Vector image using SVG tag
         if(imageData.v) {
-            html[i++] = AjxImg.createSVGTag(imageData, AjxImg.getClassForImage(imageName));
+            html[i++] = AjxImg.createSVGTag(imageData);
         }
 
         html[i++] = "</div>";
@@ -131,7 +131,7 @@ function(parentEl, imageName, useParentEl, _disabled, classes, altText) {
     if (className) {
         if (imageData.v) {
             // Vector image using SVG tag
-            parentEl.firstChild.innerHTML = AjxImg.createSVGTag(imageData, AjxImg.getClassForImage(imageName));
+            parentEl.firstChild.innerHTML = AjxImg.createSVGTag(imageData);
         }
 
         // Raster/Vector image using background
@@ -222,8 +222,7 @@ function() {
             return;
         }
 
-        var className = AjxImg.getClassForImage(imageName, disabled);
-
+        var className = AjxImg.getClassForImage(imageName + (imageData.v ? '-svg' : ''), disabled);
         if (color) {
             color = (color.match(/^\d$/) ? ZmOrganizer.COLOR_VALUES[color] : color) ||
                     ZmOrganizer.COLOR_VALUES[ZmOrganizer.ORG_DEFAULT_COLOR];
@@ -240,14 +239,14 @@ function() {
             }
 
             if(imageData.v) {
-                html = AjxImg.createSVGTag(imageData, AjxImg.getClassForImage(imageName), styleStr, attrStr);
+                html = AjxImg.createSVGTag(imageData, AjxImg.getClassForImage(imageName + '-svg'), styleStr, attrStr);
             } else {
                 DBG.println(AjxDebug.IMAGES, "No support for raster image with specific color ", AjxImg.getClassForImage(imageName));
             }
         }
         else {
             // Raster/Vector image using background
-               classes.push(AjxImg.getClassForImage(imageName));
+            classes.push(className);
 
             html = [
                 "<div ", AjxUtil.getClassAttr(classes), styleStr, attrStr, ">"
@@ -263,7 +262,7 @@ function() {
 
             // Vector image using SVG tag
             if(imageData.v) {
-                html.push(AjxImg.createSVGTag(imageData, AjxImg.getClassForImage(imageName)));
+                html.push(AjxImg.createSVGTag(imageData));
             }
 
             html.push("</div>");
@@ -301,9 +300,14 @@ function() {
 AjxImg.createSVGTag = function(imageData, imageName, styleStr, attrStr) {
     styleStr = styleStr || "";
     attrStr = attrStr || "";
+    clsStr = 'svg-icon';
+
+    if(imageName) {
+        clsStr += ' ' + imageName;
+    }
 
     var retVal = [];
-    retVal.push("<svg aria-hidden='true' class='svg-icon " + imageName + "' " + styleStr + attrStr + ">");
+    retVal.push("<svg aria-hidden='true' class='" + clsStr + "' " + styleStr + attrStr + ">");
 
     // SVG2 has deprecated xlink:href, so in future we need to use href attribute
     retVal.push("<use xlink:href=\"" + imageData.f + "\"></use>");

--- a/WebRoot/js/ajax/dwt/widgets/DwtCalendar.js
+++ b/WebRoot/js/ajax/dwt/widgets/DwtCalendar.js
@@ -940,12 +940,6 @@ function() {
 	html[idx++] = "</td></tr></table></table>";
 
 	this.getHtmlElement().innerHTML = html.join("");
-	if (!this._readOnly) {
-		document.getElementById("b:py:img:" + this._uuid)._origClassName = AjxImg.getClassForImage("FastRevArrowSmall");
-		document.getElementById("b:pm:img:" + this._uuid)._origClassName = AjxImg.getClassForImage("RevArrowSmall");
-		document.getElementById("b:nm:img:" + this._uuid)._origClassName = AjxImg.getClassForImage("FwdArrowSmall");
-		document.getElementById("b:ny:img:" + this._uuid)._origClassName = AjxImg.getClassForImage("FastFwdArrowSmall");
-	}
 
 	this._calWidgetInited = true;
 };
@@ -1006,15 +1000,11 @@ function(ev) {
 		// Dont activate title for now
 		return;
 	} else if (target.id.charAt(0) == 'b') {
-		var img;
 		if (target.firstChild == null || target.firstChild instanceof SVGElement) {
-			img = target;
 			AjxImg.getParentElement(target).className = DwtCalendar._BUTTON_HOVERED_CLASS;
 		} else {
 			target.className = DwtCalendar._BUTTON_HOVERED_CLASS;
-			img = AjxImg.getImageElement(target);
 		}
-		img.className = img._origClassName;
 	}
 
 	ev._stopPropagation = true;
@@ -1030,16 +1020,11 @@ function(ev) {
 			this._mouseOutDayCB.run(this);
 		}
 	} else if (target.id.charAt(0) == 'b') {
-		var img;
-		target.className = DwtCalendar._BUTTON_CLASS;
 		if (target.firstChild == null || target.firstChild instanceof SVGElement) {
-			img = target;
 			AjxImg.getParentElement(target).className = DwtCalendar._BUTTON_CLASS;
 		} else {
 			target.className = DwtCalendar._BUTTON_CLASS;
-			img = AjxImg.getImageElement(target);
 		}
-		img.className = img._origClassName;
 	}
 };
 
@@ -1052,15 +1037,11 @@ function(ev) {
 		} else if (target.id.charAt(0) == 't') {
 			target.className = DwtCalendar._TITLE_ACTIVE_CLASS;
 		} else if (target.id.charAt(0) == 'b') {
-			var img;
 			if (target.firstChild == null || target.firstChild instanceof SVGElement) {
-				img = target;
 				AjxImg.getParentElement(target).className = DwtCalendar._BUTTON_ACTIVE_CLASS;
 			} else {
 				target.className = DwtCalendar._BUTTON_ACTIVE_CLASS;
-				img = AjxImg.getImageElement(target);
 			}
-			img.className = img._origClassName;
 		} else if (target.id.charAt(0) == 'w') {
 		}
 	}
@@ -1091,8 +1072,7 @@ function(ev) {
 				target.className = DwtCalendar._BUTTON_HOVERED_CLASS;
 				img = AjxImg.getImageElement(target);
 			}
-			img.className = img._origClassName;
-			
+
 			if (img.id.indexOf("py") != -1) {
 				this._prevYear();
 			} else if (img.id.indexOf("pm") != -1) {

--- a/src/com/zimbra/webClient/servlet/SkinResources.java
+++ b/src/com/zimbra/webClient/servlet/SkinResources.java
@@ -151,6 +151,7 @@ public class SkinResources
 
 	private static final String N_SKIN = "skin";
 	private static final String N_IMAGES = "images";
+	private static final String N_SVGS = "svgs";
 
 	private static final String SKIN_MANIFEST = "manifest.xml";
 
@@ -174,6 +175,7 @@ public class SkinResources
     private static final Pattern RE_CSSURL = Pattern.compile("^(?!/\\*).*url\\(\'?\"?(.*?)\\??v?=?\\d*\'?\"?\\)");
 
 	private static final String IMAGE_CSS = "img/images.css";
+	private static final String SVG_CSS = "svg/svgs.css";
 
 	private static final Map<String, String> TYPES = new HashMap<String, String>();
 
@@ -616,6 +618,12 @@ public class SkinResources
 					String cssFilename = file.getName().replaceAll("\\.css$", "");
 					String cssExt = file.getName().replaceAll("^.*\\.", ".");
 					addLocaleFiles(files, requestedLocale, file.getParentFile(), cssFilename, cssExt);
+
+					file = new File(skinDir, SVG_CSS);
+					files.add(file);
+					cssFilename = file.getName().replaceAll("\\.css$", "");
+					cssExt = file.getName().replaceAll("^.*\\.", ".");
+					addLocaleFiles(files, requestedLocale, file.getParentFile(), cssFilename, cssExt);
 				}
 				else if (type.equals(T_JAVASCRIPT)) {
 					// decide whether to include templates
@@ -660,9 +668,15 @@ public class SkinResources
 				File file = new File(dir, filenameExt);
 				if (ZimbraLog.webclient.isDebugEnabled())
 					ZimbraLog.webclient.debug("DEBUG: file " + file.getAbsolutePath());
-				if (!file.exists() && (type.equals(T_CSS) || type.equals(T_APPCACHE)) && filename.equals(N_IMAGES)) {
-					file = new File(rootDir, IMAGE_CSS);
-					dir = file.getParentFile();
+				if (!file.exists() && (type.equals(T_CSS) || type.equals(T_APPCACHE))) {
+					if(filename.equals(N_IMAGES)) {
+						file = new File(rootDir, IMAGE_CSS);
+						dir = file.getParentFile();
+					} else if (filename.equals(N_SVGS)) {
+						file = new File(rootDir, SVG_CSS);
+						dir = file.getParentFile();
+					}
+
 					if (ZimbraLog.webclient.isDebugEnabled())
 						ZimbraLog.webclient.debug("DEBUG: !file.exists() " + file.getAbsolutePath());
 				}


### PR DESCRIPTION
zm-web-client
- All svg files have been moved to it's individual svg folder, and all img files are restored back so html client can use those
- build.xml is modified to do spriting of svgs in a separate folder which we can include in webclient
- all jsp files are modified to include svgs.css file which contains css selectors to use svg using background property
- removed ajax.build.dir variable from build.xml as it is not used anymore
- removed taglib-jar ant target as we are not generating jar for taglib from webclient, it is handled by ivy now

zm-ajax
- modify SkinResources.java to serve svgs.css file if requested by jsp pages
- modified AjxImg.js to add extra prefix in case of svg, so if we are using svg to render an image, the svg tag will have imagename with -svg postfix, this will make sure that we don't have name conflicts between normal and vector images, as vector images will always be reffered using -svg postfix, and normal images will be reffered using only image name
- cleanup code in AjxImg.js to make sure we are not applying same class name to multiple elements, this makes targetting specific elements easier

- DwtCalendar.js --> We shouldn't be changing class for wrapper element of next/previous buttons as AjxImg is already assigning correct classes to wrapper element, by changing it we are creating flicker effect on hover