### PR TITLE
ZCS-1795 Persistent XSS happens on textbox

### DIFF
--- a/WebRoot/js/ajax/dwt/xforms/XFormItem.js
+++ b/WebRoot/js/ajax/dwt/xforms/XFormItem.js
@@ -688,7 +688,7 @@ XFormItem.prototype.setError = function(message, childError) {
 	this.getForm().addErrorItem(this);
 	this.__errorState = XFormItem.ERROR_STATE_ERROR;
 	var container = this.getErrorContainer(true);
-	if (container) container.innerHTML = message;
+	if (container) container.innerHTML = AjxStringUtil.htmlEncode(message);
 };
 
 /** 


### PR DESCRIPTION
Issue:
- Error text in form fields were executing text in dom, which can be used for XSS attacks

Resolution:
- Before adding error to DOM, html encode the text to make sure it is not executed in browser
- This is done at a generic place so it will affect error display for all form fields