### PR TITLE
ZCS-1883 Firefox shows extra attribute style="" on mail editor(body area) form

### DIFF
--- a/WebRoot/js/ajax/util/AjxStringUtil.js
+++ b/WebRoot/js/ajax/util/AjxStringUtil.js
@@ -2258,11 +2258,15 @@ function(el, ctxt) {
         //checks for invalid styles and removes them.  Bug: 78875 - bad styles from user = email displays incorrectly
         if (el.style) {
             var style = el.style && el.style.cssText;
-            style = style.toLowerCase();
-            if (!AjxStringUtil._checkStyle(style)){
-                isCleanHtml = false;
+
+            // Ignore empty style tags, we don't want to pollute DOM by adding empty style tags
+            if (style !== "") {
+                style = style.toLowerCase();
+                if (!AjxStringUtil._checkStyle(style)){
+                    isCleanHtml = false;
+                }
+                el.style.cssText = AjxStringUtil._fixStyle(style);
             }
-            el.style.cssText = AjxStringUtil._fixStyle(style);
         }
 
 		if (el.removeAttribute && el.attributes && el.attributes.length) {


### PR DESCRIPTION
Issue:
- Code for fixing style tags was actually adding empty style attributes in dom when the origin element didn't contain any style definition

Resolution:
- when we access element.style.cssText then either it will return style attribute or empty string
- if it is style attribute then we need to fix some styles and update same style attribute in dom
- but in case of empty style we need to ignore any processing and not modify DOM, so we will not be adding empty style attibutes to elements where there was no style attribute present earlier