### PR TITLE
ZCS-1888 Universal UI: Sharing preference interface update

### DIFF
--- a/WebRoot/js/ajax/dwt/widgets/DwtListView.js
+++ b/WebRoot/js/ajax/dwt/widgets/DwtListView.js
@@ -396,7 +396,7 @@ function(htmlArr, idx, headerCol, i, numCols, id, defaultColumnSort) {
 		htmlArr[idx++] = DwtId.getListViewHdrId(DwtId.WIDGET_HDR_SASH, this._view, field);
 		htmlArr[idx++] = "'><tr>";
 		htmlArr[idx++] = "<td class='DwtListView-Sash'><div style='width: 1px; height: ";
-		htmlArr[idx++] = (DwtListView.HEADERITEM_HEIGHT - 2);
+		htmlArr[idx++] = (DwtListView.HEADERITEM_HEIGHT - 12);
         htmlArr[idx++] = "px; ";
         if(DwtListView.HEADERSASH_STYLE === 1) {
             htmlArr[idx++] = "border-left: 1px dotted #CCCCCC;";
@@ -404,7 +404,7 @@ function(htmlArr, idx, headerCol, i, numCols, id, defaultColumnSort) {
             htmlArr[idx++] = "background-color: #8A8A8A;";
         }
 		htmlArr[idx++] = " margin-left:2px'></div></td><td class='DwtListView-Sash'><div style='width: 1px; height: ";
-		htmlArr[idx++] = (DwtListView.HEADERITEM_HEIGHT - 2);
+		htmlArr[idx++] = (DwtListView.HEADERITEM_HEIGHT - 12);
 		htmlArr[idx++] = "px;'></div></td></tr></table>";
 		htmlArr[idx++] = "</td>";
 	}
@@ -1794,13 +1794,18 @@ function(dropAllowed) {
 
 DwtListView.prototype._setNoResultsHtml =
 function() {
-	var	div = document.createElement("div");
+	var div = this._getNoResultsContainer();
 	var subs = {
 		message: this._getNoResultsMessage(),
 		type: this.type
 	};
 	div.innerHTML = AjxTemplate.expand("dwt.Widgets#DwtListView-NoResults", subs);
 	this._addRow(div);
+};
+
+DwtListView.prototype._getNoResultsContainer =
+function() {
+	return document.createElement("div");
 };
 
 DwtListView.prototype._getNoResultsMessage =


### PR DESCRIPTION
Description:
 * Adding a getter function for no results container in the view. Child views can override this function and return a custom container for adding any specific UX styling.
 * Updating the column header sash height calculation, basically reducing heights from both ends so they don’t take 100% height of the column.

ChangeSet:
 * DwtListView: Adding getter function _getNoResultContainer().
 * DwtListView::_createHeader(): Updating the sash height calculation logic.