### PR TITLE
Fixed DwtBaseDialog._initializeDragging offset

### DIFF
--- a/WebRoot/js/ajax/dwt/widgets/DwtBaseDialog.js
+++ b/WebRoot/js/ajax/dwt/widgets/DwtBaseDialog.js
@@ -447,13 +447,11 @@ function(dragHandleId) {
 		if (control) {
 			var p = Dwt.getSize(control.getHtmlElement());
 			var dragObj = document.getElementById(this._htmlElId);
-			var size = this.getSize();
 			var dragEndCb = new AjxCallback(this, this._dragEnd);
 			var dragCb = new AjxCallback(this, this._duringDrag);
 			var dragStartCb = new AjxCallback(this, this._dragStart);
 
-			DwtDraggable.init(dragHandle, dragObj, 0,
-							  document.body.offsetWidth - 10, 0, document.body.offsetHeight - 10, dragStartCb, dragCb, dragEndCb);
+			DwtDraggable.init(dragHandle, dragObj, 0, p.x - 10, 0, p.y - 10, dragStartCb, dragCb, dragEndCb);
 		}
 	}
 };


### PR DESCRIPTION
https://bugzilla.zimbra.com/show_bug.cgi?id=103201

During the initialization of the dragging of the DwtBaseDialog a wrong offset was calculated resulting in a dialog locked with Y=0 and X movable.
This patch initialize the correct boundaries to let the dialog to be dragged everywhere in the window.

How to reproduce:
- Open the admin console
- Popup a dialog, Your choice
- Click on the title bar of the dialog and drag the dialog

What happens:
- The dialog is moved on the top of the window and can slide only in X coordinates

Expected:
- The dialog must follow the mouse movements