### PR TITLE
ZCS-904 Support SVG sprite in IE11

### DIFF
--- a/WebRoot/js/ajax/package/Ajax.js
+++ b/WebRoot/js/ajax/package/Ajax.js
@@ -139,4 +139,4 @@ AjxPackage.require("ajax.dwt.widgets.DwtComboBox");
 AjxPackage.require("ajax.dwt.widgets.DwtTimeSelect");
 
 AjxPackage.require("ajax.3rdparty.jquery.jquery");
-
+AjxPackage.require("ajax.3rdparty.svg4everybody.svg4everybody");


### PR DESCRIPTION
- If svg4everybody lib is available then enable it's support in IE11