### PR TITLE
Corrected order of `enterButton` in `DwtDialog`

### DIFF
--- a/WebRoot/js/ajax/dwt/widgets/DwtDialog.js
+++ b/WebRoot/js/ajax/dwt/widgets/DwtDialog.js
@@ -87,7 +87,7 @@ DwtDialog = function(params) {
 	if (standardButtons || extraButtons) {
 		this._buttonDesc = {};
 		if (standardButtons && standardButtons.length) {
-			this._initialEnterButtonId = this._enterButtonId = standardButtons[0];
+			this._initialEnterButtonId = this._enterButtonId = standardButtons[standardButtons.length - 1];
 			for (var i = 0; i < standardButtons.length; i++) {
 				var buttonId = standardButtons[i];
 				this._buttonList.push(buttonId);


### PR DESCRIPTION
Issue:

* While working on standard modal style changes, we had to sort standard buttons so that `DwtDialog.OK_BUTTON` and `DwtDialog.YES_BUTTON` always comes last in `standardButtons` array (which makes them render right in dialogs)
* However because of this `enterButtonId` also changed, since it always takes first item from `standardButtons `

Fix:
* `enterButtonId `has been set as last element of  `standardButtons` which is always `DwtDialog.OK_BUTTON` or `DwtDialog.YES_BUTTON`