### PR TITLE
ZCS-1583: Restore "legacy" behaviour of `AjxImg` to support use of raster images from zimlets

### DIFF
--- a/WebRoot/js/ajax/core/AjxImg.js
+++ b/WebRoot/js/ajax/core/AjxImg.js
@@ -69,12 +69,7 @@ function(parentEl, imageName, useParentEl, _disabled, classes, altText) {
     }
 
     // Get image data based on image name
-    var imageData = window.AjxImgData[AjxImg.getClassForImage(imageName)];
-    if(!imageData) {
-        DBG.println(AjxDebug.IMAGES, "missing image: ", AjxImg.getClassForImage(imageName));
-
-        return;
-    }
+    var imageData = window.AjxImgData[AjxImg.getClassForImage(imageName)] || {};
 
     var className = AjxImg.getClassForImage(imageName + (imageData.v ? '-svg' : ''), _disabled);
     if (useParentEl) {
@@ -215,12 +210,7 @@ function() {
         }
 
         // Get image data based on image name
-        var imageData = window.AjxImgData[AjxImg.getClassForImage(imageName)];
-        if(!imageData) {
-            DBG.println(AjxDebug.IMAGES, "missing image: ", AjxImg.getClassForImage(imageName));
-
-            return;
-        }
+        var imageData = window.AjxImgData[AjxImg.getClassForImage(imageName)] || {};
 
         var className = AjxImg.getClassForImage(imageName + (imageData.v ? '-svg' : ''), disabled);
         if (color) {


### PR DESCRIPTION
* Updated `AjxImg.setImage` and `AjxImg.getImageHtml` method to remove condition for checking presence of image data in `window.AjxImgData` (Images for Zimlets will not be present in `AjxImgData` object)

https://jira.corp.synacor.com/browse/ZCS-1583