### PR TITLE
Bugzilla-77129: display received time in email list

### DIFF
--- a/WebRoot/js/ajax/util/AjxDateUtil.js
+++ b/WebRoot/js/ajax/util/AjxDateUtil.js
@@ -81,10 +81,17 @@ function() {
 			segments[i] = new AjxDateFormat.YearSegment(AjxDateUtil._dateFormat, "yyyy");
 		}
 	}
-	AjxDateUtil._dateTimeFormat = 
-		new AjxDateFormat(AjxDateUtil._dateFormat.toPattern() + " " + AjxDateFormat.getTimeInstance(AjxDateFormat.SHORT));
+
+	AjxDateUtil._dateTimeFormat = new AjxDateFormat(I18nMsg.formatDateTimeShort);
+	segments = AjxDateUtil._dateTimeFormat.getSegments();
+	for (i = 0; i < segments.length; i++) {
+		if (segments[i] instanceof AjxDateFormat.YearSegment) {
+			segments[i] = new AjxDateFormat.YearSegment(AjxDateUtil._dateTimeFormat, "yyyy");
+		}
+	}
 
 	AjxDateUtil._dateFormatNoYear = new AjxDateFormat(AjxMsg.formatDateMediumNoYear);
+	AjxDateUtil._dateTimeFormatNoYear = new AjxDateFormat(AjxMsg.formatDateTimeMediumNoYear);
 };
 
 AjxDateUtil._init();                    
@@ -288,17 +295,24 @@ function(now, dateMSec, requireTime) {
 		return "";
 
 	var date = new Date(dateMSec);
-	var time = AjxDateUtil.computeTimeString(date);
 	if (now.getTime() - dateMSec < AjxDateUtil.MSEC_PER_DAY &&
 		now.getDay() == date.getDay()) {
-		return time;
+		return AjxDateUtil.computeTimeString(date);
 	}
 
 	if (now.getFullYear() == date.getFullYear()) {
-		return AjxDateUtil._dateFormatNoYear.format(date) + (requireTime ? " " + time : "");
+		if (requireTime) {
+			return AjxDateUtil._dateTimeFormatNoYear.format(date);
+		} else {
+			return AjxDateUtil._dateFormatNoYear.format(date);
+		}
 	}
 
-	return AjxDateUtil.simpleComputeDateStr(date) + (requireTime ? " " + time : "");
+	if (requireTime) {
+		return AjxDateUtil.simpleComputeDateTimeStr(date);
+	} else {
+		return AjxDateUtil.simpleComputeDateStr(date);
+	}
 };
 
 AjxDateUtil.computeDateStrNoYear =

--- a/WebRoot/js/ajax/util/AjxDateUtil.js
+++ b/WebRoot/js/ajax/util/AjxDateUtil.js
@@ -283,21 +283,22 @@ function(date) {
 }
 
 AjxDateUtil.computeDateStr =
-function(now, dateMSec) {
+function(now, dateMSec, requireTime) {
 	if (dateMSec == null)
 		return "";
 
 	var date = new Date(dateMSec);
+	var time = AjxDateUtil.computeTimeString(date);
 	if (now.getTime() - dateMSec < AjxDateUtil.MSEC_PER_DAY &&
 		now.getDay() == date.getDay()) {
-		return AjxDateUtil.computeTimeString(date);
+		return time;
 	}
 
 	if (now.getFullYear() == date.getFullYear()) {
-		return AjxDateUtil._dateFormatNoYear.format(date);
+		return AjxDateUtil._dateFormatNoYear.format(date) + (requireTime ? " " + time : "");
 	}
 
-	return AjxDateUtil.simpleComputeDateStr(date);
+	return AjxDateUtil.simpleComputeDateStr(date) + (requireTime ? " " + time : "");
 };
 
 AjxDateUtil.computeDateStrNoYear =

--- a/WebRoot/messages/AjxMsg.properties
+++ b/WebRoot/messages/AjxMsg.properties
@@ -26,6 +26,7 @@ formatShortCalMonth = MMM yyyy
 
 # additional formats for date formatting
 formatDateMediumNoYear = MMM dd 
+formatDateTimeMediumNoYear = MMM dd h:mm a
 formatWordyDateToday = 'Today,' h:mm a
 formatWordyDateYesterday = 'Yesterday,' h:mm a
 formatWordyDate = EEE, M/d/yy, h:mm a

--- a/WebRoot/messages/AjxMsg_ar.properties
+++ b/WebRoot/messages/AjxMsg_ar.properties
@@ -26,6 +26,7 @@ formatShortCalMonth = MMM yyyy
 
 # additional formats for date formatting
 formatDateMediumNoYear = dd MMM 
+formatDateTimeMediumNoYear = dd MMM h:mm a
 formatWordyDateToday = '\u0627\u0644\u064a\u0648\u0645\u060c' h:mm a
 formatWordyDateYesterday = '\u0623\u0645\u0633\u060c' h:mm a
 formatWordyDate = EEE d/M/yy\u060c h:mm a

--- a/WebRoot/messages/AjxMsg_ca.properties
+++ b/WebRoot/messages/AjxMsg_ca.properties
@@ -26,6 +26,7 @@ formatShortCalMonth = MMM de yyyy
 
 # additional formats for date formatting
 formatDateMediumNoYear = dd MMM 
+formatDateTimeMediumNoYear = dd MMM HH:mm
 			formatWordyDateToday = 'Avui,' H:mm
 			formatWordyDateYesterday = 'Ahir,' H:mm
 formatWordyDate = EEE, d/M/yy, H:mm

--- a/WebRoot/messages/AjxMsg_da.properties
+++ b/WebRoot/messages/AjxMsg_da.properties
@@ -26,6 +26,7 @@ formatShortCalMonth = MMM yyyy
 
 # additional formats for date formatting
 formatDateMediumNoYear = dd. MMM 
+formatDateTimeMediumNoYear = dd. MMM HH:mm
 formatWordyDateToday = 'I dag,' HH:mm
 formatWordyDateYesterday = 'I g\u00e5r,' HH:mm
 formatWordyDate = EEE dd/MM/yy HH:mm

--- a/WebRoot/messages/AjxMsg_de.properties
+++ b/WebRoot/messages/AjxMsg_de.properties
@@ -26,6 +26,7 @@ formatShortCalMonth = MMM yyyy
 
 # additional formats for date formatting
 formatDateMediumNoYear = dd. MMM. 
+formatDateTimeMediumNoYear = dd. MMM. H:mm
 formatWordyDateToday = 'Heute,' H:mm
 formatWordyDateYesterday = 'Gestern,' H:mm
 formatWordyDate = EEE, d.M.yy, H:mm

--- a/WebRoot/messages/AjxMsg_en_AU.properties
+++ b/WebRoot/messages/AjxMsg_en_AU.properties
@@ -26,6 +26,7 @@ formatShortCalMonth = MMM yyyy
 
 # additional formats for date formatting
 formatDateMediumNoYear = dd MMM 
+formatDateTimeMediumNoYear = dd MMM h:mm a
 formatWordyDateToday = 'Today,' h:mm a
 formatWordyDateYesterday = 'Yesterday,' h:mm a
 formatWordyDate = EEE, d/M/yy, h:mm a

--- a/WebRoot/messages/AjxMsg_en_GB.properties
+++ b/WebRoot/messages/AjxMsg_en_GB.properties
@@ -26,6 +26,7 @@ formatShortCalMonth = MMM yyyy
 
 # additional formats for date formatting
 formatDateMediumNoYear = dd MMM 
+formatDateTimeMediumNoYear = dd MMM HH:mm
 formatWordyDateToday = 'Today,' HH:mm
 formatWordyDateYesterday = 'Yesterday,' HH:mm
 formatWordyDate = EEE, d/M/yy, HH:mm

--- a/WebRoot/messages/AjxMsg_es.properties
+++ b/WebRoot/messages/AjxMsg_es.properties
@@ -26,6 +26,7 @@ formatShortCalMonth = MMM 'de' yyyy
 
 # additional formats for date formatting
 formatDateMediumNoYear = dd 'de' MMM 
+formatDateTimeMediumNoYear = dd 'de' MMM HH:mm
 formatWordyDateToday = 'Hoy,' H:mm
 formatWordyDateYesterday = 'Ayer,' H:mm
 formatWordyDate = EEE, d/MM/yy, H:mm

--- a/WebRoot/messages/AjxMsg_eu.properties
+++ b/WebRoot/messages/AjxMsg_eu.properties
@@ -26,6 +26,7 @@ formatShortCalMonth = yyyy MMM
 
 # additional formats for date formatting
 formatDateMediumNoYear = MMM dd 
+formatDateTimeMediumNoYear = MMM dd HH:mm
 formatWordyDateToday = 'Gaur,' H:mm
 formatWordyDateYesterday = 'Atzo,' H:mm
 formatWordyDate = yy/M/d, EEE, H:mm

--- a/WebRoot/messages/AjxMsg_fr.properties
+++ b/WebRoot/messages/AjxMsg_fr.properties
@@ -26,6 +26,7 @@ formatShortCalMonth = MMM yyyy
 
 # additional formats for date formatting
 formatDateMediumNoYear = dd MMM 
+formatDateTimeMediumNoYear = dd MMM H:mm
 formatWordyDateToday = 'Aujourd\u2019hui,' HH:mm
 formatWordyDateYesterday = 'Hier,' HH:mm
 formatWordyDate = EEE d/M/yy, HH:mm

--- a/WebRoot/messages/AjxMsg_fr_CA.properties
+++ b/WebRoot/messages/AjxMsg_fr_CA.properties
@@ -26,6 +26,7 @@ formatShortCalMonth = MMM yyyy
 
 # additional formats for date formatting
 formatDateMediumNoYear = dd MMM 
+formatDateTimeMediumNoYear = dd MMM HH:mm
 formatWordyDateToday = 'Aujourd'hui,' HH:mm
 formatWordyDateYesterday = 'Hier,' HH:mm
 formatWordyDate = EEE d/M/yy, HH:mm

--- a/WebRoot/messages/AjxMsg_hi.properties
+++ b/WebRoot/messages/AjxMsg_hi.properties
@@ -26,6 +26,7 @@ formatShortCalMonth = MMM yyyy
 
 # additional formats for date formatting
 formatDateMediumNoYear = dd MMM 
+formatDateTimeMediumNoYear = dd MMM h:mm a
 formatWordyDateToday = '\u0906\u091c,' h:mm a
 formatWordyDateYesterday = '\u092c\u0940\u0924\u093e \u0915\u0932,' h:mm a
 formatWordyDate = EEE, d/M/yy, h:mm a

--- a/WebRoot/messages/AjxMsg_hu.properties
+++ b/WebRoot/messages/AjxMsg_hu.properties
@@ -26,6 +26,7 @@ formatShortCalMonth = yyyy MMM
 
 # additional formats for date formatting
 formatDateMediumNoYear = MMM dd
+formatDateTimeMediumNoYear = MMM dd H:mm
 formatWordyDateToday = 'Ma,' H:mm
 formatWordyDateYesterday = 'Tegnap,' H:mm
 formatWordyDate = EEE, yy.MM.d., H:mm

--- a/WebRoot/messages/AjxMsg_in.properties
+++ b/WebRoot/messages/AjxMsg_in.properties
@@ -26,6 +26,7 @@ formatShortCalMonth = MMM yyyy
 
 # additional formats for date formatting
 formatDateMediumNoYear = dd MMM 
+formatDateTimeMediumNoYear = dd MMM HH:mm
 formatWordyDateToday = 'Hari Ini,' HH:mm
 formatWordyDateYesterday = 'Kemarin,' HH:mm
 formatWordyDate = EEE, d/M/yy, HH:mm

--- a/WebRoot/messages/AjxMsg_it.properties
+++ b/WebRoot/messages/AjxMsg_it.properties
@@ -26,6 +26,7 @@ formatShortCalMonth = MMM yyyy
 
 # additional formats for date formatting
 formatDateMediumNoYear = dd MMM 
+formatDateTimeMediumNoYear = dd MMM H:mm
 formatWordyDateToday = 'Oggi,' H:mm
 formatWordyDateYesterday = 'Ieri,' H:mm
 formatWordyDate = EEE, d/MM/yy, H:mm

--- a/WebRoot/messages/AjxMsg_iw.properties
+++ b/WebRoot/messages/AjxMsg_iw.properties
@@ -26,6 +26,7 @@ formatShortCalMonth = MMM yyyy\u200f
 
 # additional formats for date formatting
 formatDateMediumNoYear = dd\u200f MMM  
+formatDateTimeMediumNoYear = dd\u200f MMM h:mm a\u200f
 formatWordyDateToday = '\u05d4\u05d9\u05d5\u05dd,' H:mm
 formatWordyDateYesterday = '\u05d0\u05ea\u05de\u05d5\u05dc,' H:mm
 formatWordyDate = EEE, M/d/yy, H:mm\u200f

--- a/WebRoot/messages/AjxMsg_ja.properties
+++ b/WebRoot/messages/AjxMsg_ja.properties
@@ -26,6 +26,7 @@ formatShortCalMonth = yyyy\u5e74 MMM
 
 # additional formats for date formatting
 formatDateMediumNoYear = M\u6708d\u65e5 
+formatDateTimeMediumNoYear = M\u6708d\u65e5 a K:mm
 formatWordyDateToday = '\u4eca\u65e5,' a h:mm
 formatWordyDateYesterday = '\u6628\u65e5,' a h:mm
 formatWordyDate = yy/M/d, EEE, a h:mm

--- a/WebRoot/messages/AjxMsg_ko.properties
+++ b/WebRoot/messages/AjxMsg_ko.properties
@@ -26,6 +26,7 @@ formatShortCalMonth = yyyy\ub144 MMM
 
 # additional formats for date formatting
 formatDateMediumNoYear = MMM dd\uc77c 
+formatDateTimeMediumNoYear = MMM dd\uc77c a h:mm
 formatWordyDateToday = '\uc624\ub298,' a h:mm
 formatWordyDateYesterday = '\uc5b4\uc81c,' a h:mm
 formatWordyDate = yy/M/d (EEE) a h:mm

--- a/WebRoot/messages/AjxMsg_lo.properties
+++ b/WebRoot/messages/AjxMsg_lo.properties
@@ -26,6 +26,7 @@ formatShortCalMonth = MMM yyyy
 
 # additional formats for date formatting
 formatDateMediumNoYear = dd MMM
+formatDateTimeMediumNoYear = dd MMM H:mm
 formatWordyDateToday = '\u0ea1\u0eb7\u0ec9\u0e99\u0eb5\u0ec9,' H:mm
 formatWordyDateYesterday = '\u0ea1\u0eb7\u0ec9\u0ea7\u0eb2\u0e99\u0e99\u0eb5\u0ec9,' H:mm
 formatWordyDate = EEE, d/M/yy H:mm

--- a/WebRoot/messages/AjxMsg_ms.properties
+++ b/WebRoot/messages/AjxMsg_ms.properties
@@ -26,6 +26,7 @@ formatShortCalMonth = MMM yyyy
 
 # additional formats for date formatting
 formatDateMediumNoYear = dd MMMM
+formatDateTimeMediumNoYear = dd MMMM h:mm a
 formatWordyDateToday = 'Hari ini,' h:mm a
 formatWordyDateYesterday = 'Semalam,' h:mm a
 formatWordyDate = EEE d/M/yy, h:mm a

--- a/WebRoot/messages/AjxMsg_nl.properties
+++ b/WebRoot/messages/AjxMsg_nl.properties
@@ -26,6 +26,7 @@ formatShortCalMonth = MMM yyyy
 
 # additional formats for date formatting
 formatDateMediumNoYear = dd MMM 
+formatDateTimeMediumNoYear = dd MMM H:mm
 formatWordyDateToday = 'Vandaag,' H:mm
 formatWordyDateYesterday = 'Gisteren,' H:mm
 formatWordyDate = EEE d/M/yy, H:mm

--- a/WebRoot/messages/AjxMsg_no.properties
+++ b/WebRoot/messages/AjxMsg_no.properties
@@ -26,6 +26,7 @@ formatShortCalMonth = MMM yyyy
 
 # additional formats for date formatting
 formatDateMediumNoYear = dd. MMM 
+formatDateTimeMediumNoYear = dd. MMM H:mm
 formatWordyDateToday = 'I dag,' H:mm
 formatWordyDateYesterday = 'I g\u00e5r,' H:mm
 formatWordyDate = EEE, d.M.yy, H:mm

--- a/WebRoot/messages/AjxMsg_pl.properties
+++ b/WebRoot/messages/AjxMsg_pl.properties
@@ -26,6 +26,7 @@ formatShortCalMonth = MMM yyyy
 
 # additional formats for date formatting
 formatDateMediumNoYear = dd MMM
+formatDateTimeMediumNoYear = dd MMM H:mm
 formatWordyDateToday = 'Dzisiaj,' H:mm
 formatWordyDateYesterday = 'Wczoraj,' H:mm
 formatWordyDate = EEE, yy-MM-d, H:mm

--- a/WebRoot/messages/AjxMsg_pt.properties
+++ b/WebRoot/messages/AjxMsg_pt.properties
@@ -26,6 +26,7 @@ formatShortCalMonth = MMM 'de' yyyy
 
 # additional formats for date formatting
 formatDateMediumNoYear = dd 'de' MMM 
+formatDateTimeMediumNoYear = dd 'de' MMM H:mm
 formatWordyDateToday = 'Hoje, \u00e0s' H:mm
 formatWordyDateYesterday = 'Ontem, \u00e0s' H:mm
 formatWordyDate = EEE, d/MM/yy, H:mm

--- a/WebRoot/messages/AjxMsg_pt_BR.properties
+++ b/WebRoot/messages/AjxMsg_pt_BR.properties
@@ -26,6 +26,7 @@ formatShortCalMonth = MMM 'de' yyyy
 
 # additional formats for date formatting
 formatDateMediumNoYear = dd 'de' MMM 
+formatDateTimeMediumNoYear = dd 'de' MMM H:mm
 formatWordyDateToday = 'Hoje,' H:mm
 formatWordyDateYesterday = 'Ontem,' H:mm
 formatWordyDate = EEE, d/MM/yy, H:mm

--- a/WebRoot/messages/AjxMsg_ro.properties
+++ b/WebRoot/messages/AjxMsg_ro.properties
@@ -26,6 +26,7 @@ formatShortCalMonth = MMM yyyy
 
 # additional formats for date formatting
 formatDateMediumNoYear = dd MMM
+formatDateTimeMediumNoYear = dd MMM H:mm
 formatWordyDateToday = 'Azi', H:mm
 formatWordyDateYesterday = 'Ieri', H:mm
 formatWordyDate = EEE, d.MM.yy, H:mm

--- a/WebRoot/messages/AjxMsg_ru.properties
+++ b/WebRoot/messages/AjxMsg_ru.properties
@@ -26,6 +26,7 @@ formatShortCalMonth = MMM yyyy
 
 # additional formats for date formatting
 formatDateMediumNoYear = dd MMM 
+formatDateTimeMediumNoYear = dd MMM H:mm
 formatWordyDateToday = '\u0421\u0435\u0433\u043e\u0434\u043d\u044f,' H:mm
 formatWordyDateYesterday = '\u0412\u0447\u0435\u0440\u0430,' H:mm
 formatWordyDate = EEE, d.MM.yy H:mm

--- a/WebRoot/messages/AjxMsg_sl.properties
+++ b/WebRoot/messages/AjxMsg_sl.properties
@@ -26,6 +26,7 @@ formatShortCalMonth = MMM. yyyy
 
 # additional formats for date formatting
 formatDateMediumNoYear = dd. MMM.
+formatDateTimeMediumNoYear = dd. MMM. HH:mm
 formatWordyDateToday = 'Danes,' HH:mm
 formatWordyDateYesterday = 'V\u010deraj,' HH:mm
 formatWordyDate = EEE, d.M.yy, HH:mm

--- a/WebRoot/messages/AjxMsg_sv.properties
+++ b/WebRoot/messages/AjxMsg_sv.properties
@@ -26,6 +26,7 @@ formatShortCalMonth = MMM yyyy
 
 # additional formats for date formatting
 formatDateMediumNoYear = dd MMM 
+formatDateTimeMediumNoYear = dd MMM 'kl 'H:mm
 formatWordyDateToday = 'Idag,' HH:mm
 formatWordyDateYesterday = 'Ig\u00e5r,' HH:mm
 formatWordyDate = EEE, dd-MM-yy, HH:mm

--- a/WebRoot/messages/AjxMsg_th.properties
+++ b/WebRoot/messages/AjxMsg_th.properties
@@ -26,6 +26,7 @@ formatShortCalMonth = MMM yyyy
 
 # additional formats for date formatting
 formatDateMediumNoYear = dd MMM 
+formatDateTimeMediumNoYear = dd MMM h:mm a
 formatWordyDateToday = '\u0e27\u0e31\u0e19\u0e19\u0e35\u0e49' h:mm a
 formatWordyDateYesterday = '\u0e40\u0e21\u0e37\u0e48\u0e2d\u0e27\u0e32\u0e19\u0e19\u0e35\u0e49' h:mm a
 formatWordyDate = EEE, d/M/yy, h:mm a

--- a/WebRoot/messages/AjxMsg_tr.properties
+++ b/WebRoot/messages/AjxMsg_tr.properties
@@ -26,6 +26,7 @@ formatShortCalMonth = MMM yyyy
 
 # additional formats for date formatting
 formatDateMediumNoYear = dd MMMM 
+formatDateTimeMediumNoYear = dd MMMM H:mm
 formatWordyDateToday = 'Bug\u00fcn,' H:mm
 formatWordyDateYesterday = 'D\u00fcn,' H:mm
 formatWordyDate = d/M/yy EEE, H:mm

--- a/WebRoot/messages/AjxMsg_uk.properties
+++ b/WebRoot/messages/AjxMsg_uk.properties
@@ -26,6 +26,7 @@ formatShortCalMonth = MMM yyyy
 
 # additional formats for date formatting
 formatDateMediumNoYear = dd MMM
+formatDateTimeMediumNoYear = dd MMM H:mm
 formatWordyDateToday = '\u0421\u044c\u043e\u0433\u043e\u0434\u043d\u0456,' H:mm
 formatWordyDateYesterday = '\u0412\u0447\u043e\u0440\u0430,' H:mm
 formatWordyDate = EEE, d.MM.yy, H:mm

--- a/WebRoot/messages/AjxMsg_zh_CN.properties
+++ b/WebRoot/messages/AjxMsg_zh_CN.properties
@@ -26,6 +26,7 @@ formatShortCalMonth = yyyy\u5e74 M\u6708
 
 # additional formats for date formatting
 formatDateMediumNoYear = MMMMdd\u65e5 
+formatDateTimeMediumNoYear = MMMMdd\u65e5 a h:mm
 formatWordyDateToday = '\u4eca\u5929,' a h:mm
 formatWordyDateYesterday = '\u6628\u5929,' a h:mm
 formatWordyDate = EEE, yy/M/d, a h:mm

--- a/WebRoot/messages/AjxMsg_zh_HK.properties
+++ b/WebRoot/messages/AjxMsg_zh_HK.properties
@@ -26,6 +26,7 @@ formatShortCalMonth = yyyy\u5e74M\u6708
 
 # additional formats for date formatting
 formatDateMediumNoYear = MMMMdd\u65e5 
+formatDateTimeMediumNoYear = MMMMdd\u65e5 a h:mm
 formatWordyDateToday = '\u4eca\u5929,' a h:mm
 formatWordyDateYesterday = '\u6628\u5929,' a h:mm
 formatWordyDate = yy/M/d, EEE, a h:mm

--- a/WebRoot/messages/AjxMsg_zh_TW.properties
+++ b/WebRoot/messages/AjxMsg_zh_TW.properties
@@ -26,6 +26,7 @@ formatShortCalMonth = yyyy MMM
 
 # additional formats for date formatting
 formatDateMediumNoYear = MMM dd 
+formatDateTimeMediumNoYear = MMM dd a h:mm
 formatWordyDateToday = '\u4eca\u5929,'a h:mm
 formatWordyDateYesterday = '\u6628\u5929,'a h:mm
 formatWordyDate = yy/M/d EEE, a h:mm

--- a/WebRoot/messages/I18nMsg.properties
+++ b/WebRoot/messages/I18nMsg.properties
@@ -26,6 +26,7 @@ formatDateMedium = MMM d, yyyy
 formatDateShort = M/d/yy
 formatDateNumber=M/d/yyyy
 formatDateTime = {0} {1}
+formatDateTimeShort = M/d/yy h:mm a
 formatNumber = #,##0.###
 formatNumberCurrency = \u00a4#,##0.00;(\u00a4#,##0.00)
 formatNumberInteger = #,##0

--- a/WebRoot/messages/I18nMsg_ar.properties
+++ b/WebRoot/messages/I18nMsg_ar.properties
@@ -26,6 +26,7 @@ formatDateMedium = d MMM\u060c yyyy
 formatDateShort = d/M/yy
 formatDateNumber=d/M/yyyy
 formatDateTime = {0} {1}
+formatDateTimeShort = d/M/yy h:mm a
 formatNumber = #.##0,###
 formatNumberCurrency = \u00a4 #.##0,00;\u00a4 #.##0,00-
 formatNumberInteger = #.##0

--- a/WebRoot/messages/I18nMsg_ca.properties
+++ b/WebRoot/messages/I18nMsg_ca.properties
@@ -26,6 +26,7 @@ formatDateMedium = d MMM 'de' yyyy
 formatDateShort = d/M/yy
 formatDateNumber=d/M/yyyy
 formatDateTime = {0} {1}
+formatDateTimeShort = d/M/yy HH:mm
 formatNumber = #,##0.###
 formatNumberCurrency = \u00a4#,##0.00;(\u00a4#,##0.00)
 formatNumberInteger = #,##0

--- a/WebRoot/messages/I18nMsg_da.properties
+++ b/WebRoot/messages/I18nMsg_da.properties
@@ -26,6 +26,7 @@ formatDateMedium = d. MMM yyyy
 formatDateShort = d-M-yy
 formatDateNumber=d/M/yyyy
 formatDateTime = {0} {1}
+formatDateTimeShort = d-M-yy HH:mm
 formatNumber = #.##0,###
 formatNumberCurrency = \u00a4 #.##0,00;(\u00a4 #.##0,00)
 formatNumberInteger = #.##0

--- a/WebRoot/messages/I18nMsg_de.properties
+++ b/WebRoot/messages/I18nMsg_de.properties
@@ -26,6 +26,7 @@ formatDateMedium = d. MMM yyyy
 formatDateShort = d.M.yy
 formatDateNumber=d.M.yyyy
 formatDateTime = {0} {1}
+formatDateTimeShort = d.M.yy H:mm
 formatNumber = #.##0,###
 formatNumberCurrency = #.##0,00 \u00a4;(#.##0,00 \u00a4)
 formatNumberInteger = #.##0

--- a/WebRoot/messages/I18nMsg_en_AU.properties
+++ b/WebRoot/messages/I18nMsg_en_AU.properties
@@ -26,6 +26,7 @@ formatDateMedium = d MMM, yyyy
 formatDateShort = d/M/yy
 formatDateNumber=d/M/yyyy
 formatDateTime = {0} {1}
+formatDateTimeShort = d/M/yy h:mm a
 formatNumber = #,##0.###
 formatNumberCurrency = \u00a4#,##0.00;(\u00a4#,##0.00)
 formatNumberInteger = #,##0

--- a/WebRoot/messages/I18nMsg_en_GB.properties
+++ b/WebRoot/messages/I18nMsg_en_GB.properties
@@ -26,6 +26,7 @@ formatDateMedium = d MMM, yyyy
 formatDateShort = d/M/yy
 formatDateNumber=d/M/yyyy
 formatDateTime = {0} {1}
+formatDateTimeShort = d/M/yy HH:mm
 formatNumber = #,##0.###
 formatNumberCurrency = \u00a4#,##0.00;(\u00a4#,##0.00)
 formatNumberInteger = #,##0

--- a/WebRoot/messages/I18nMsg_es.properties
+++ b/WebRoot/messages/I18nMsg_es.properties
@@ -26,6 +26,7 @@ formatDateMedium = d 'de' MMM 'de' yyyy
 formatDateShort = d/M/yy
 formatDateNumber=d/M/yyyy
 formatDateTime = {0} {1}
+formatDateTimeShort = d/M/yy HH:mm
 formatNumber = #.##0,###
 formatNumberCurrency = #.##0,00 \u00a4;(#.##0,00 \u00a4)
 formatNumberInteger = #.##0

--- a/WebRoot/messages/I18nMsg_eu.properties
+++ b/WebRoot/messages/I18nMsg_eu.properties
@@ -26,6 +26,7 @@ formatDateMedium = yyyy'(e)ko' MMMM'k' d
 formatDateShort = yy/M/d
 formatDateNumber = yyyy/M/d
 formatDateTime = {0} {1}
+formatDateTimeShort = yy/M/d HH:mm
 formatNumber = #,##0.###
 formatNumberCurrency = \u00a4#,##0.00;(\u00a4#,##0.00)
 formatNumberInteger = #,##0

--- a/WebRoot/messages/I18nMsg_fr.properties
+++ b/WebRoot/messages/I18nMsg_fr.properties
@@ -26,6 +26,7 @@ formatDateMedium = d MMM yy
 formatDateShort = d/M/yy
 formatDateNumber=d/M/yyyy
 formatDateTime = {0} {1}
+formatDateTimeShort = d/M/yy H:mm
 formatNumber = #.##0,###
 formatNumberCurrency = #.##0,00 \u00a4;(#.##0,00 \u00a4)
 formatNumberInteger = #.##0

--- a/WebRoot/messages/I18nMsg_fr_CA.properties
+++ b/WebRoot/messages/I18nMsg_fr_CA.properties
@@ -26,6 +26,7 @@ formatDateMedium = d MMM yyyy
 formatDateShort = d/M/yy
 formatDateNumber=d/M/yyyy
 formatDateTime = {0} {1}
+formatDateTimeShort = d/M/yy HH:mm
 formatNumber = #,##0.###
 formatNumberCurrency = \u00a4#,##0.00;(\u00a4#,##0.00)
 formatNumberInteger = #,##0

--- a/WebRoot/messages/I18nMsg_hi.properties
+++ b/WebRoot/messages/I18nMsg_hi.properties
@@ -26,6 +26,7 @@ formatDateMedium = d MMM, yyyy
 formatDateShort = d/M/yy
 formatDateNumber=d/M/yyyy
 formatDateTime = {0} {1}
+formatDateTimeShort = d/M/yy h:mm a
 formatNumber = #,##0.###
 formatNumberCurrency = \u00a4#,##0.00;(\u00a4#,##0.00)
 formatNumberInteger = #,##0

--- a/WebRoot/messages/I18nMsg_hu.properties
+++ b/WebRoot/messages/I18nMsg_hu.properties
@@ -26,6 +26,7 @@ formatDateMedium = yyyy. MMM. d.
 formatDateShort = yyyy.MM.dd.
 formatDateNumber=yyyy.M.d.
 formatDateTime = {0} {1}
+formatDateTimeShort = yyyy.MM.dd. H:mm
 formatNumber = #.##0,###
 formatNumberCurrency = \u00a4#.##0,00;(\u00a4#.##0,00)
 formatNumberInteger = #.##0

--- a/WebRoot/messages/I18nMsg_in.properties
+++ b/WebRoot/messages/I18nMsg_in.properties
@@ -26,6 +26,7 @@ formatDateMedium = d MMM yyyy
 formatDateShort = d/M/yy
 formatDateNumber=d/M/yyyy
 formatDateTime = {0} {1}
+formatDateTimeShort = d/M/yy HH:mm
 formatNumber = #,##0.###
 formatNumberCurrency = \u00a4#,##0.00;(\u00a4#,##0.00)
 formatNumberInteger = #,##0

--- a/WebRoot/messages/I18nMsg_it.properties
+++ b/WebRoot/messages/I18nMsg_it.properties
@@ -26,6 +26,7 @@ formatDateMedium = d-MMM-yy
 formatDateShort = d/M/yy
 formatDateNumber=M/d/yyyy
 formatDateTime = {0} {1}
+formatDateTimeShort = d/M/yy H:mm
 formatNumber = #.##0,###
 formatNumberCurrency = \u00a4 #.##0,00;(\u00a4 #.##0,00)
 formatNumberInteger = #.##0

--- a/WebRoot/messages/I18nMsg_iw.properties
+++ b/WebRoot/messages/I18nMsg_iw.properties
@@ -26,6 +26,7 @@ formatDateMedium = d MMM yyyy\u200f
 formatDateShort = d/M/yy\u200f
 formatDateNumber=d/M/yyyy\u200f
 formatDateTime = {0} {1}
+formatDateTimeShort = d/M/yy\u200f h:mm a\u200f
 formatNumber = #,##0.###
 formatNumberCurrency = \u00a4#,##0.00;(\u00a4#,##0.00)
 formatNumberInteger = #,##0

--- a/WebRoot/messages/I18nMsg_ja.properties
+++ b/WebRoot/messages/I18nMsg_ja.properties
@@ -26,6 +26,7 @@ formatDateMedium = yyyy'\u5e74'M'\u6708'd'\u65e5'
 formatDateShort = yy/M/d
 formatDateNumber=yyyy/M/d
 formatDateTime = {0} {1}
+formatDateTimeShort = yy/M/d a K:mm
 formatNumber = #,##0.###
 formatNumberCurrency = \u00a4#,##0.00;(\u00a4#,##0.00)
 formatNumberInteger = #,##0

--- a/WebRoot/messages/I18nMsg_ko.properties
+++ b/WebRoot/messages/I18nMsg_ko.properties
@@ -26,6 +26,7 @@ formatDateMedium = yyyy\ub144 MMM d\uc77c
 formatDateShort = yy. M. d
 formatDateNumber=yyyy\ub144 M\uc6d4 d\uc77c
 formatDateTime = {0} {1}
+formatDateTimeShort = yy. M. d a h:mm
 formatNumber = #,##0.###
 formatNumberCurrency = \u00a4#,##0.00;(\u00a4#,##0.00)
 formatNumberInteger = #,##0

--- a/WebRoot/messages/I18nMsg_lo.properties
+++ b/WebRoot/messages/I18nMsg_lo.properties
@@ -26,6 +26,7 @@ formatDateMedium = d MMM yyyy
 formatDateShort = d/M/yy
 formatDateNumber=d/M/yyyy
 formatDateTime = {0} {1}
+formatDateTimeShort = d/M/yy H:mm
 formatNumber = #,##0.###
 formatNumberCurrency = \u00a4#,##0.00;(\u00a4#,##0.00)
 formatNumberInteger = #,##0

--- a/WebRoot/messages/I18nMsg_ms.properties
+++ b/WebRoot/messages/I18nMsg_ms.properties
@@ -26,6 +26,7 @@ formatDateMedium = d MMM yyyy
 formatDateShort = d/M/yy
 formatDateNumber=d/M/yyyy
 formatDateTime = {0} {1}
+formatDateTimeShort = d/M/yy h:mm a
 formatNumber = #.##0,###
 formatNumberCurrency = \u00a4#.##0,00;(\u00a4#.##0,00)
 formatNumberInteger = #.##0

--- a/WebRoot/messages/I18nMsg_nl.properties
+++ b/WebRoot/messages/I18nMsg_nl.properties
@@ -26,6 +26,7 @@ formatDateMedium = d MMM yyyy
 formatDateShort = d-M-yy
 formatDateNumber=M/d/yyyy
 formatDateTime = {0} {1}
+formatDateTimeShort = d-M-yy H:mm
 formatNumber = #.##0,###
 formatNumberCurrency = \u00a4#.##0,00;(\u00a4#.##0,00)
 formatNumberInteger = #.##0

--- a/WebRoot/messages/I18nMsg_no.properties
+++ b/WebRoot/messages/I18nMsg_no.properties
@@ -26,6 +26,7 @@ formatDateMedium = d. MMM yyyy
 formatDateShort = d.M.yy
 formatDateNumber=d.M.yyyy
 formatDateTime = {0} {1}
+formatDateTimeShort = d.M.yy H:mm
 formatNumber = #,##0.###
 formatNumberCurrency = \u00a4#,##0.00;(\u00a4#,##0.00)
 formatNumberInteger = #,##0

--- a/WebRoot/messages/I18nMsg_pl.properties
+++ b/WebRoot/messages/I18nMsg_pl.properties
@@ -26,6 +26,7 @@ formatDateMedium = d MMM, yyyy
 formatDateShort = yy-M-d
 formatDateNumber=yyyy-M-d
 formatDateTime = {0} {1}
+formatDateTimeShort = yy-M-d H:mm
 formatNumber = #.##0,###
 formatNumberCurrency = #.##0,00 \u00a4;(#.##0,00 \u00a4)
 formatNumberInteger = #.##0

--- a/WebRoot/messages/I18nMsg_pt.properties
+++ b/WebRoot/messages/I18nMsg_pt.properties
@@ -26,6 +26,7 @@ formatDateMedium = d 'de' MMM 'de' yyyy
 formatDateShort = d/MM/yy
 formatDateNumber=d/MM/yyyy
 formatDateTime = {0} {1}
+formatDateTimeShort = d/MM/yy H:mm
 formatNumber = #,##0.###
 formatNumberCurrency = \u00a4#,##0.00;(\u00a4#,##0.00)
 formatNumberInteger = #,##0

--- a/WebRoot/messages/I18nMsg_pt_BR.properties
+++ b/WebRoot/messages/I18nMsg_pt_BR.properties
@@ -26,6 +26,7 @@ formatDateMedium = d 'de' MMM 'de' yyyy
 formatDateShort = d/M/yy
 formatDateNumber=M/d/aaaa
 formatDateTime = {0} {1}
+formatDateTimeShort = d/M/yy H:mm
 formatNumber = #.##0,###
 formatNumberCurrency = \u00a4 #.##0,00;(\u00a4 #.##0,00)
 formatNumberInteger = #.##0

--- a/WebRoot/messages/I18nMsg_ro.properties
+++ b/WebRoot/messages/I18nMsg_ro.properties
@@ -26,6 +26,7 @@ formatDateMedium = d MMM, yyyy
 formatDateShort = d.M.yy
 formatDateNumber=d.M.yyyy
 formatDateTime = {0} {1}
+formatDateTimeShort = d.M.yy H:mm
 formatNumber = #.##0,###
 formatNumberCurrency = \u00a4#.##0,00;(\u00a4#.##0,00)
 formatNumberInteger = #.##0

--- a/WebRoot/messages/I18nMsg_ru.properties
+++ b/WebRoot/messages/I18nMsg_ru.properties
@@ -26,6 +26,7 @@ formatDateMedium = d MMM yyyy '\u0433.'
 formatDateShort = d.M.yy
 formatDateNumber=\u041c/\u0434/\u0433\u0433\u0433\u0433
 formatDateTime = {0} {1}
+formatDateTimeShort = d.M.yy H:mm
 formatNumber = # ##0,###
 formatNumberCurrency = # ##0,00 \u00a4;(# ##0,00 \u00a4)
 formatNumberInteger = # ##0

--- a/WebRoot/messages/I18nMsg_sl.properties
+++ b/WebRoot/messages/I18nMsg_sl.properties
@@ -26,6 +26,7 @@ formatDateMedium = d. MMM. yyyy
 formatDateShort = d.M.yy
 formatDateNumber=d.M.yyyy
 formatDateTime = {0} {1}
+formatDateTimeShort = d.M.yy HH:mm
 formatNumber = #,##0.###
 formatNumberCurrency = \u00a4#,##0.00;(\u00a4#,##0.00)
 formatNumberInteger = #,##0

--- a/WebRoot/messages/I18nMsg_sv.properties
+++ b/WebRoot/messages/I18nMsg_sv.properties
@@ -26,6 +26,7 @@ formatDateMedium = d MMM yyyy
 formatDateShort = yyyy-MM-dd
 formatDateNumber=yyyy-MM-dd
 formatDateTime = {0} {1}
+formatDateTimeShort = yyyy-MM-dd 'kl 'H:mm
 formatNumber = #.##0,###
 formatNumberCurrency = #.##0,00 \u00a4;(#.##0,00 \u00a4)
 formatNumberInteger = #.##0

--- a/WebRoot/messages/I18nMsg_th.properties
+++ b/WebRoot/messages/I18nMsg_th.properties
@@ -26,6 +26,7 @@ formatDateMedium = d MMM, yyyy
 formatDateShort = d/M/yy
 formatDateNumber=d/M/yyyy
 formatDateTime = {0} {1}
+formatDateTimeShort = d/M/yy h:mm a
 formatNumber = #,##0.###
 formatNumberCurrency = \u00a4#,##0.00;(\u00a4#,##0.00)
 formatNumberInteger = #,##0

--- a/WebRoot/messages/I18nMsg_tr.properties
+++ b/WebRoot/messages/I18nMsg_tr.properties
@@ -26,6 +26,7 @@ formatDateMedium = d MMM yyyy
 formatDateShort = d.M.yy
 formatDateNumber=d.M.yyyy
 formatDateTime = {0} {1}
+formatDateTimeShort = d.M.yy H:mm
 formatNumber = #.##0,###
 formatNumberCurrency = \u00a4#.##0,00;(\u00a4#.##0,00)
 formatNumberInteger = #.##0

--- a/WebRoot/messages/I18nMsg_uk.properties
+++ b/WebRoot/messages/I18nMsg_uk.properties
@@ -26,6 +26,7 @@ formatDateMedium = d MMM yyyy '\u0440'
 formatDateShort = d.M.yy
 formatDateNumber=d.M.yyyy
 formatDateTime = {0} {1}
+formatDateTimeShort = d.M.yy H:mm
 formatNumber = # ##0,###
 formatNumberCurrency = u00a4# ##0,00;(u00a4# ##0,00)
 formatNumberInteger = # ##0

--- a/WebRoot/messages/I18nMsg_zh.properties
+++ b/WebRoot/messages/I18nMsg_zh.properties
@@ -28,6 +28,7 @@ formatTimeFull = ahh'\u65f6'mm'\u5206'ss'\u79d2' z
 formatTimeLong = ahh'\u65f6'mm'\u5206'ss'\u79d2'
 formatTimeMedium = H:mm:ss
 formatTimeShort = ah:mm
+formatDateTimeShort = yy-M-d ah:mm
 monthAprLong = \u56db\u6708
 monthAprMedium = \u56db\u6708
 monthAugLong = \u516b\u6708

--- a/WebRoot/messages/I18nMsg_zh_CN.properties
+++ b/WebRoot/messages/I18nMsg_zh_CN.properties
@@ -26,6 +26,7 @@ formatDateMedium = yyyy-MM-dd
 formatDateShort = yy-M-d
 formatDateNumber=yyyy/M/d
 formatDateTime = {0} {1}
+formatDateTimeShort = yy-M-d a h:mm
 formatNumber = #,##0.###
 formatNumberCurrency = \u00a4 #,##0.00;(\u00a4 #,##0.00)
 formatNumberInteger = #,##0

--- a/WebRoot/messages/I18nMsg_zh_HK.properties
+++ b/WebRoot/messages/I18nMsg_zh_HK.properties
@@ -26,6 +26,7 @@ formatDateMedium = yyyy/M/d
 formatDateShort = yyyy\u5e74M\u6708d\u65e5
 formatDateNumber=\u6708\uff0f\u65e5\uff0f\u5e74
 formatDateTime = {0} {1}
+formatDateTimeShort = yyyy\u5e74M\u6708d\u65e5 a h:mm
 formatNumber = #,##0.###
 formatNumberCurrency = \u00a4#,##0.00;(\u00a4#,##0.00)
 formatNumberInteger = #,##0

--- a/WebRoot/messages/I18nMsg_zh_TW.properties
+++ b/WebRoot/messages/I18nMsg_zh_TW.properties
@@ -26,6 +26,7 @@ formatDateMedium = yyyy-MMM-d
 formatDateShort = yy/M/d
 formatDateNumber=yyyy/M/d
 formatDateTime = {0} {1}
+formatDateTimeShort = yy/M/d a h:mm
 formatNumber = #,##0.###
 formatNumberCurrency = \u00a4 #,##0.00;(\u00a4 #,##0.00)
 formatNumberInteger = #,##0


### PR DESCRIPTION
[Adding feature]
- If zimbraPrefDisplayTimeInMailList is TRUE, web client displays not only date but also time of a message received yesterday or before in email list.
- Adding a setting in Preferences -> Mail tab

[Related]
- Jira ticket id: NICPS-30
- Pull requests:
-- https://github.com/Zimbra/zm-web-client/pull/227
-- https://github.com/Zimbra/zm-mailbox/pull/528