### PR TITLE
ZCS-4023 Fix tinymce upgrade related bugs

### DIFF
--- a/WebRoot/messages/AjxMsg.properties
+++ b/WebRoot/messages/AjxMsg.properties
@@ -251,16 +251,16 @@ fontFamilyBase13.display = ###
 # TODO: Should we expose the base font families for translation?
 #L10N_IGNORE_BLOCK_BEGIN
 fontFamilyBase1.css = arial, helvetica, sans-serif
-fontFamilyBase2.css = 'times new roman', 'new york', times, serif
-fontFamilyBase3.css = 'arial black','avant garde'
-fontFamilyBase4.css = 'courier new', courier, monaco, monospace, sans-serif
-fontFamilyBase5.css = 'comic sans ms', 'comic sans', sans-serif
-fontFamilyBase6.css = 'lucida console', sans-serif
-fontFamilyBase7.css = garamond, 'new york', times, serif
+fontFamilyBase2.css = times new roman, new york, times, serif
+fontFamilyBase3.css = arial black,avant garde
+fontFamilyBase4.css = courier new, courier, monaco, monospace, sans-serif
+fontFamilyBase5.css = comic sans ms, comic sans, sans-serif
+fontFamilyBase6.css = lucida console, sans-serif
+fontFamilyBase7.css = garamond, new york, times, serif
 fontFamilyBase8.css = georgia,serif
-fontFamilyBase9.css = tahoma, 'new york', times, serif
+fontFamilyBase9.css = tahoma, new york, times, serif
 fontFamilyBase10.css = terminal,monaco
-fontFamilyBase11.css = 'trebuchet ms',sans-serif
+fontFamilyBase11.css = trebuchet ms,sans-serif
 fontFamilyBase12.css = verdana, helvetica, sans-serif
 fontFamilyBase13.css = ###
 #L10N_IGNORE_BLOCK_END

--- a/WebRoot/messages/AjxMsg_ar.properties
+++ b/WebRoot/messages/AjxMsg_ar.properties
@@ -207,10 +207,6 @@ sizeBytes = \u0628\u0627\u064a\u062a
 # For formatting file sizes (e.g. "123.4 MB")
 formatSizeAndUnits = {0} {1}
 
-#L10N_IGNORE_BLOCK_BEGIN
-fontSizes = 8pt 9pt 10pt 11pt 12pt 13pt 14pt 16pt 18pt 24pt 36pt 48pt
-#L10N_IGNORE_BLOCK_END
-
 # The font family options specified below are a list of fonts for
 # HTML compose. Each value is a comma-separated list of font names
 # to be used. The entries whose key ends in ".display" is used as
@@ -246,23 +242,6 @@ fontFamilyBase10.display = Terminal
 fontFamilyBase11.display = Modern
 fontFamilyBase12.display = Wide
 fontFamilyBase13.display = ###
-
-# TODO: Should we expose the base font families for translation?
-#L10N_IGNORE_BLOCK_BEGIN
-fontFamilyBase1.css = arial, helvetica, sans-serif
-fontFamilyBase2.css = 'times new roman', 'new york', times, serif
-fontFamilyBase3.css = 'arial black','avant garde'
-fontFamilyBase4.css = 'courier new', courier, monaco, monospace, sans-serif
-fontFamilyBase5.css = 'comic sans ms', 'comic sans', sans-serif
-fontFamilyBase6.css = 'lucida console', sans-serif
-fontFamilyBase7.css = garamond, 'new york', times, serif
-fontFamilyBase8.css = georgia,serif
-fontFamilyBase9.css = tahoma, 'new york', times, serif
-fontFamilyBase10.css = terminal,monaco
-fontFamilyBase11.css = 'trebuchet ms',sans-serif
-fontFamilyBase12.css = verdana, helvetica, sans-serif
-fontFamilyBase13.css = ###
-#L10N_IGNORE_BLOCK_END
 
 # These will be set by the various translations
 fontFamilyIntl1.display = ###

--- a/WebRoot/messages/AjxMsg_ca.properties
+++ b/WebRoot/messages/AjxMsg_ca.properties
@@ -207,10 +207,6 @@ sizeBytes     = B
 # For formatting file sizes (e.g. "123.4 MB")
 formatSizeAndUnits = {0} {1}
 
-#L10N_IGNORE_BLOCK_BEGIN
-fontSizes = 8pt 9pt 10pt 11pt 12pt 13pt 14pt 16pt 18pt 24pt 36pt 48pt
-#L10N_IGNORE_BLOCK_END
-
 # The font family options specified below are a list of fonts for
 # HTML compose. Each value is a comma-separated list of font names
 # to be used. The entries whose key ends in ".display" is used as
@@ -246,23 +242,6 @@ fontFamilyBase10.display = Terminal
 fontFamilyBase11.display = Modern
 fontFamilyBase12.display = Ample
 fontFamilyBase13.display = ###
-
-# TODO: Should we expose the base font families for translation?
-#L10N_IGNORE_BLOCK_BEGIN
-fontFamilyBase1.css = arial, helvetica, sans-serif
-fontFamilyBase2.css = 'times new roman', 'new york', times, serif
-fontFamilyBase3.css = 'arial black','avant garde'
-fontFamilyBase4.css = 'courier new', courier, monaco, monospace, sans-serif
-fontFamilyBase5.css = 'comic sans ms', 'comic sans', sans-serif
-fontFamilyBase6.css = 'lucida console', sans-serif
-fontFamilyBase7.css = garamond, 'new york', times, serif
-fontFamilyBase8.css = georgia,serif
-fontFamilyBase9.css = tahoma, 'new york', times, serif
-fontFamilyBase10.css = terminal,monaco
-fontFamilyBase11.css = 'trebuchet ms',sans-serif
-fontFamilyBase12.css = verdana, helvetica, sans-serif
-fontFamilyBase13.css = ###
-#L10N_IGNORE_BLOCK_END
 
 # These will be set by the various translations
 fontFamilyIntl1.display = ###

--- a/WebRoot/messages/AjxMsg_da.properties
+++ b/WebRoot/messages/AjxMsg_da.properties
@@ -207,10 +207,6 @@ sizeBytes = B
 # For formatting file sizes (e.g. "123.4 MB")
 formatSizeAndUnits = {0} {1}
 
-#L10N_IGNORE_BLOCK_BEGIN
-fontSizes = 8pt 9pt 10pt 11pt 12pt 13pt 14pt 16pt 18pt 24pt 36pt 48pt
-#L10N_IGNORE_BLOCK_END
-
 # The font family options specified below are a list of fonts for
 # HTML compose. Each value is a comma-separated list of font names
 # to be used. The entries whose key ends in ".display" is used as
@@ -246,23 +242,6 @@ fontFamilyBase10.display = Terminal
 fontFamilyBase11.display = Modern
 fontFamilyBase12.display = Wide
 fontFamilyBase13.display = ###
-
-# TODO: Should we expose the base font families for translation?
-#L10N_IGNORE_BLOCK_BEGIN
-fontFamilyBase1.css = arial, helvetica, sans-serif
-fontFamilyBase2.css = 'times new roman', 'new york', times, serif
-fontFamilyBase3.css = 'arial black','avant garde'
-fontFamilyBase4.css = 'courier new', courier, monaco, monospace, sans-serif
-fontFamilyBase5.css = 'comic sans ms', 'comic sans', sans-serif
-fontFamilyBase6.css = 'lucida console', sans-serif
-fontFamilyBase7.css = garamond, 'new york', times, serif
-fontFamilyBase8.css = georgia,serif
-fontFamilyBase9.css = tahoma, 'new york', times, serif
-fontFamilyBase10.css = terminal,monaco
-fontFamilyBase11.css = 'trebuchet ms',sans-serif
-fontFamilyBase12.css = verdana, helvetica, sans-serif
-fontFamilyBase13.css = ###
-#L10N_IGNORE_BLOCK_END
 
 # These will be set by the various translations
 fontFamilyIntl1.display = ###

--- a/WebRoot/messages/AjxMsg_de.properties
+++ b/WebRoot/messages/AjxMsg_de.properties
@@ -207,10 +207,6 @@ sizeBytes = B
 # For formatting file sizes (e.g. "123.4 MB")
 formatSizeAndUnits = {0} {1}
 
-#L10N_IGNORE_BLOCK_BEGIN
-fontSizes = 8pt 9pt 10pt 11pt 12pt 13pt 14pt 16pt 18pt 24pt 36pt 48pt
-#L10N_IGNORE_BLOCK_END
-
 # The font family options specified below are a list of fonts for
 # HTML compose. Each value is a comma-separated list of font names
 # to be used. The entries whose key ends in ".display" is used as
@@ -246,23 +242,6 @@ fontFamilyBase10.display = Terminal
 fontFamilyBase11.display = Modern
 fontFamilyBase12.display = Wide
 fontFamilyBase13.display = ###
-
-# TODO: Should we expose the base font families for translation?
-#L10N_IGNORE_BLOCK_BEGIN
-fontFamilyBase1.css = arial, helvetica, sans-serif
-fontFamilyBase2.css = 'times new roman', 'new york', times, serif
-fontFamilyBase3.css = 'arial black','avant garde'
-fontFamilyBase4.css = 'courier new', courier, monaco, monospace, sans-serif
-fontFamilyBase5.css = 'comic sans ms', 'comic sans', sans-serif
-fontFamilyBase6.css = 'lucida console', sans-serif
-fontFamilyBase7.css = garamond, 'new york', times, serif
-fontFamilyBase8.css = georgia,serif
-fontFamilyBase9.css = tahoma, 'new york', times, serif
-fontFamilyBase10.css = terminal,monaco
-fontFamilyBase11.css = 'trebuchet ms',sans-serif
-fontFamilyBase12.css = verdana, helvetica, sans-serif
-fontFamilyBase13.css = ###
-#L10N_IGNORE_BLOCK_END
 
 # These will be set by the various translations
 fontFamilyIntl1.display = ###

--- a/WebRoot/messages/AjxMsg_en_AU.properties
+++ b/WebRoot/messages/AjxMsg_en_AU.properties
@@ -207,10 +207,6 @@ sizeBytes = B
 # For formatting file sizes (e.g. "123.4 MB")
 formatSizeAndUnits = {0} {1}
 
-#L10N_IGNORE_BLOCK_BEGIN
-fontSizes = 8pt 9pt 10pt 11pt 12pt 13pt 14pt 16pt 18pt 24pt 36pt 48pt
-#L10N_IGNORE_BLOCK_END
-
 # The font family options specified below are a list of fonts for
 # HTML compose. Each value is a comma-separated list of font names
 # to be used. The entries whose key ends in ".display" is used as
@@ -246,23 +242,6 @@ fontFamilyBase10.display = Terminal
 fontFamilyBase11.display = Modern
 fontFamilyBase12.display = Wide
 fontFamilyBase13.display = ###
-
-# TODO: Should we expose the base font families for translation?
-#L10N_IGNORE_BLOCK_BEGIN
-fontFamilyBase1.css = arial, helvetica, sans-serif
-fontFamilyBase2.css = 'times new roman', 'new york', times, serif
-fontFamilyBase3.css = 'arial black','avant garde'
-fontFamilyBase4.css = 'courier new', courier, monaco, monospace, sans-serif
-fontFamilyBase5.css = 'comic sans ms', 'comic sans', sans-serif
-fontFamilyBase6.css = 'lucida console', sans-serif
-fontFamilyBase7.css = garamond, 'new york', times, serif
-fontFamilyBase8.css = georgia,serif
-fontFamilyBase9.css = tahoma, 'new york', times, serif
-fontFamilyBase10.css = terminal,monaco
-fontFamilyBase11.css = 'trebuchet ms',sans-serif
-fontFamilyBase12.css = verdana, helvetica, sans-serif
-fontFamilyBase13.css = ###
-#L10N_IGNORE_BLOCK_END
 
 # These will be set by the various translations
 fontFamilyIntl1.display = ###

--- a/WebRoot/messages/AjxMsg_en_GB.properties
+++ b/WebRoot/messages/AjxMsg_en_GB.properties
@@ -207,10 +207,6 @@ sizeBytes = B
 # For formatting file sizes (e.g. "123.4 MB")
 formatSizeAndUnits = {0} {1}
 
-#L10N_IGNORE_BLOCK_BEGIN
-fontSizes = 8pt 9pt 10pt 11pt 12pt 13pt 14pt 16pt 18pt 24pt 36pt 48pt
-#L10N_IGNORE_BLOCK_END
-
 # The font family options specified below are a list of fonts for
 # HTML compose. Each value is a comma-separated list of font names
 # to be used. The entries whose key ends in ".display" is used as
@@ -246,23 +242,6 @@ fontFamilyBase10.display = Terminal
 fontFamilyBase11.display = Modern
 fontFamilyBase12.display = Wide
 fontFamilyBase13.display = ###
-
-# TODO: Should we expose the base font families for translation?
-#L10N_IGNORE_BLOCK_BEGIN
-fontFamilyBase1.css = arial, helvetica, sans-serif
-fontFamilyBase2.css = 'times new roman', 'new york', times, serif
-fontFamilyBase3.css = 'arial black','avant garde'
-fontFamilyBase4.css = 'courier new', courier, monaco, monospace, sans-serif
-fontFamilyBase5.css = 'comic sans ms', 'comic sans', sans-serif
-fontFamilyBase6.css = 'lucida console', sans-serif
-fontFamilyBase7.css = garamond, 'new york', times, serif
-fontFamilyBase8.css = georgia,serif
-fontFamilyBase9.css = tahoma, 'new york', times, serif
-fontFamilyBase10.css = terminal,monaco
-fontFamilyBase11.css = 'trebuchet ms',sans-serif
-fontFamilyBase12.css = verdana, helvetica, sans-serif
-fontFamilyBase13.css = ###
-#L10N_IGNORE_BLOCK_END
 
 # These will be set by the various translations
 fontFamilyIntl1.display = ###

--- a/WebRoot/messages/AjxMsg_es.properties
+++ b/WebRoot/messages/AjxMsg_es.properties
@@ -207,10 +207,6 @@ sizeBytes = B
 # For formatting file sizes (e.g. "123.4 MB")
 formatSizeAndUnits = {0} {1}
 
-#L10N_IGNORE_BLOCK_BEGIN
-fontSizes = 8pt 9pt 10pt 11pt 12pt 13pt 14pt 16pt 18pt 24pt 36pt 48pt
-#L10N_IGNORE_BLOCK_END
-
 # The font family options specified below are a list of fonts for
 # HTML compose. Each value is a comma-separated list of font names
 # to be used. The entries whose key ends in ".display" is used as
@@ -246,23 +242,6 @@ fontFamilyBase10.display = Terminal
 fontFamilyBase11.display = Modern
 fontFamilyBase12.display = Wide
 fontFamilyBase13.display = ###
-
-# TODO: Should we expose the base font families for translation?
-#L10N_IGNORE_BLOCK_BEGIN
-fontFamilyBase1.css = arial, helvetica, sans-serif
-fontFamilyBase2.css = 'times new roman', 'new york', times, serif
-fontFamilyBase3.css = 'arial black','avant garde'
-fontFamilyBase4.css = 'courier new', courier, monaco, monospace, sans-serif
-fontFamilyBase5.css = 'comic sans ms', 'comic sans', sans-serif
-fontFamilyBase6.css = 'lucida console', sans-serif
-fontFamilyBase7.css = garamond, 'new york', times, serif
-fontFamilyBase8.css = georgia,serif
-fontFamilyBase9.css = tahoma, 'new york', times, serif
-fontFamilyBase10.css = terminal,monaco
-fontFamilyBase11.css = 'trebuchet ms',sans-serif
-fontFamilyBase12.css = verdana, helvetica, sans-serif
-fontFamilyBase13.css = ###
-#L10N_IGNORE_BLOCK_END
 
 # These will be set by the various translations
 fontFamilyIntl1.display = ###

--- a/WebRoot/messages/AjxMsg_eu.properties
+++ b/WebRoot/messages/AjxMsg_eu.properties
@@ -207,10 +207,6 @@ sizeBytes = B
 # For formatting file sizes (e.g. "123.4 MB")
 formatSizeAndUnits = {0} {1}
 
-#L10N_IGNORE_BLOCK_BEGIN
-fontSizes = 8pt 9pt 10pt 11pt 12pt 13pt 14pt 16pt 18pt 24pt 36pt 48pt
-#L10N_IGNORE_BLOCK_END
-
 # The font family options specified below are a list of fonts for
 # HTML compose. Each value is a comma-separated list of font names
 # to be used. The entries whose key ends in ".display" is used as
@@ -246,23 +242,6 @@ fontFamilyBase10.display = Terminal
 fontFamilyBase11.display = Modern
 fontFamilyBase12.display = Wide
 fontFamilyBase13.display = ###
-
-# TODO: Should we expose the base font families for translation?
-#L10N_IGNORE_BLOCK_BEGIN
-fontFamilyBase1.css = arial, helvetica, sans-serif
-fontFamilyBase2.css = 'times new roman', 'new york', times, serif
-fontFamilyBase3.css = 'arial black','avant garde'
-fontFamilyBase4.css = 'courier new', courier, monaco, monospace, sans-serif
-fontFamilyBase5.css = 'comic sans ms', 'comic sans', sans-serif
-fontFamilyBase6.css = 'lucida console', sans-serif
-fontFamilyBase7.css = garamond, 'new york', times, serif
-fontFamilyBase8.css = georgia,serif
-fontFamilyBase9.css = tahoma, 'new york', times, serif
-fontFamilyBase10.css = terminal,monaco
-fontFamilyBase11.css = 'trebuchet ms',sans-serif
-fontFamilyBase12.css = verdana, helvetica, sans-serif
-fontFamilyBase13.css = ###
-#L10N_IGNORE_BLOCK_END
 
 # These will be set by the various translations
 fontFamilyIntl1.display = ###

--- a/WebRoot/messages/AjxMsg_fr.properties
+++ b/WebRoot/messages/AjxMsg_fr.properties
@@ -207,10 +207,6 @@ sizeBytes = o
 # For formatting file sizes (e.g. "123.4 MB")
 formatSizeAndUnits = {0} {1}
 
-#L10N_IGNORE_BLOCK_BEGIN
-fontSizes = 8pt 9pt 10pt 11pt 12pt 13pt 14pt 16pt 18pt 24pt 36pt 48pt
-#L10N_IGNORE_BLOCK_END
-
 # The font family options specified below are a list of fonts for
 # HTML compose. Each value is a comma-separated list of font names
 # to be used. The entries whose key ends in ".display" is used as
@@ -246,23 +242,6 @@ fontFamilyBase10.display = Terminal
 fontFamilyBase11.display = Modern
 fontFamilyBase12.display = Wide
 fontFamilyBase13.display = ###
-
-# TODO: Should we expose the base font families for translation?
-#L10N_IGNORE_BLOCK_BEGIN
-fontFamilyBase1.css = arial, helvetica, sans-serif
-fontFamilyBase2.css = 'times new roman', 'new york', times, serif
-fontFamilyBase3.css = 'arial black','avant garde'
-fontFamilyBase4.css = 'courier new', courier, monaco, monospace, sans-serif
-fontFamilyBase5.css = 'comic sans ms', 'comic sans', sans-serif
-fontFamilyBase6.css = 'lucida console', sans-serif
-fontFamilyBase7.css = garamond, 'new york', times, serif
-fontFamilyBase8.css = georgia,serif
-fontFamilyBase9.css = tahoma, 'new york', times, serif
-fontFamilyBase10.css = terminal,monaco
-fontFamilyBase11.css = 'trebuchet ms',sans-serif
-fontFamilyBase12.css = verdana, helvetica, sans-serif
-fontFamilyBase13.css = ###
-#L10N_IGNORE_BLOCK_END
 
 # These will be set by the various translations
 fontFamilyIntl1.display = ###

--- a/WebRoot/messages/AjxMsg_fr_CA.properties
+++ b/WebRoot/messages/AjxMsg_fr_CA.properties
@@ -207,10 +207,6 @@ sizeBytes = o
 # For formatting file sizes (e.g. "123.4 MB")
 formatSizeAndUnits = {0} {1}
 
-#L10N_IGNORE_BLOCK_BEGIN
-fontSizes = 8pt 9pt 10pt 11pt 12pt 13pt 14pt 16pt 18pt 24pt 36pt 48pt
-#L10N_IGNORE_BLOCK_END
-
 # The font family options specified below are a list of fonts for
 # HTML compose. Each value is a comma-separated list of font names
 # to be used. The entries whose key ends in ".display" is used as
@@ -246,23 +242,6 @@ fontFamilyBase10.display = Terminal
 fontFamilyBase11.display = Modern
 fontFamilyBase12.display = Wide
 fontFamilyBase13.display = ###
-
-# TODO: Should we expose the base font families for translation?
-#L10N_IGNORE_BLOCK_BEGIN
-fontFamilyBase1.css = arial, helvetica, sans-serif
-fontFamilyBase2.css = 'times new roman', 'new york', times, serif
-fontFamilyBase3.css = 'arial black','avant garde'
-fontFamilyBase4.css = 'courier new', courier, monaco, monospace, sans-serif
-fontFamilyBase5.css = 'comic sans ms', 'comic sans', sans-serif
-fontFamilyBase6.css = 'lucida console', sans-serif
-fontFamilyBase7.css = garamond, 'new york', times, serif
-fontFamilyBase8.css = georgia,serif
-fontFamilyBase9.css = tahoma, 'new york', times, serif
-fontFamilyBase10.css = terminal,monaco
-fontFamilyBase11.css = 'trebuchet ms',sans-serif
-fontFamilyBase12.css = verdana, helvetica, sans-serif
-fontFamilyBase13.css = ###
-#L10N_IGNORE_BLOCK_END
 
 # These will be set by the various translations
 fontFamilyIntl1.display = ###

--- a/WebRoot/messages/AjxMsg_hi.properties
+++ b/WebRoot/messages/AjxMsg_hi.properties
@@ -207,10 +207,6 @@ sizeBytes = \u092c\u0940
 # For formatting file sizes (e.g. "123.4 MB")
 formatSizeAndUnits = {0} {1}
 
-#L10N_IGNORE_BLOCK_BEGIN
-fontSizes = 8pt 9pt 10pt 11pt 12pt 13pt 14pt 16pt 18pt 24pt 36pt 48pt
-#L10N_IGNORE_BLOCK_END
-
 # The font family options specified below are a list of fonts for
 # HTML compose. Each value is a comma-separated list of font names
 # to be used. The entries whose key ends in ".display" is used as
@@ -246,23 +242,6 @@ fontFamilyBase10.display = Terminal
 fontFamilyBase11.display = Modern
 fontFamilyBase12.display = Wide
 fontFamilyBase13.display = ###
-
-# TODO: Should we expose the base font families for translation?
-#L10N_IGNORE_BLOCK_BEGIN
-fontFamilyBase1.css = arial, helvetica, sans-serif
-fontFamilyBase2.css = 'times new roman', 'new york', times, serif
-fontFamilyBase3.css = 'arial black','avant garde'
-fontFamilyBase4.css = 'courier new', courier, monaco, monospace, sans-serif
-fontFamilyBase5.css = 'comic sans ms', 'comic sans', sans-serif
-fontFamilyBase6.css = 'lucida console', sans-serif
-fontFamilyBase7.css = garamond, 'new york', times, serif
-fontFamilyBase8.css = georgia,serif
-fontFamilyBase9.css = tahoma, 'new york', times, serif
-fontFamilyBase10.css = terminal,monaco
-fontFamilyBase11.css = 'trebuchet ms',sans-serif
-fontFamilyBase12.css = verdana, helvetica, sans-serif
-fontFamilyBase13.css = ###
-#L10N_IGNORE_BLOCK_END
 
 # These will be set by the various translations
 fontFamilyIntl1.display = ###

--- a/WebRoot/messages/AjxMsg_hu.properties
+++ b/WebRoot/messages/AjxMsg_hu.properties
@@ -207,10 +207,6 @@ sizeBytes = B
 # For formatting file sizes (e.g. "123.4 MB")
 formatSizeAndUnits = {0} {1}
 
-#L10N_IGNORE_BLOCK_BEGIN
-fontSizes = 8pt 9pt 10pt 11pt 12pt 13pt 14pt 16pt 18pt 24pt 36pt 48pt
-#L10N_IGNORE_BLOCK_END
-
 # The font family options specified below are a list of fonts for
 # HTML compose. Each value is a comma-separated list of font names
 # to be used. The entries whose key ends in ".display" is used as
@@ -246,23 +242,6 @@ fontFamilyBase10.display = Terminal
 fontFamilyBase11.display = Modern
 fontFamilyBase12.display = Wide
 fontFamilyBase13.display = ###
-
-# TODO: Should we expose the base font families for translation?
-#L10N_IGNORE_BLOCK_BEGIN
-fontFamilyBase1.css = arial, helvetica, sans-serif
-fontFamilyBase2.css = 'times new roman', 'new york', times, serif
-fontFamilyBase3.css = 'arial black','avant garde'
-fontFamilyBase4.css = 'courier new', courier, monaco, monospace, sans-serif
-fontFamilyBase5.css = 'comic sans ms', 'comic sans', sans-serif
-fontFamilyBase6.css = 'lucida console', sans-serif
-fontFamilyBase7.css = garamond, 'new york', times, serif
-fontFamilyBase8.css = georgia,serif
-fontFamilyBase9.css = tahoma, 'new york', times, serif
-fontFamilyBase10.css = terminal,monaco
-fontFamilyBase11.css = 'trebuchet ms',sans-serif
-fontFamilyBase12.css = verdana, helvetica, sans-serif
-fontFamilyBase13.css = ###
-#L10N_IGNORE_BLOCK_END
 
 # These will be set by the various translations
 fontFamilyIntl1.display = ###

--- a/WebRoot/messages/AjxMsg_in.properties
+++ b/WebRoot/messages/AjxMsg_in.properties
@@ -207,10 +207,6 @@ sizeBytes = B
 # For formatting file sizes (e.g. "123.4 MB")
 formatSizeAndUnits = {0} {1}
 
-#L10N_IGNORE_BLOCK_BEGIN
-fontSizes = 8pt 9pt 10pt 11pt 12pt 13pt 14pt 16pt 18pt 24pt 36pt 48pt
-#L10N_IGNORE_BLOCK_END
-
 # The font family options specified below are a list of fonts for
 # HTML compose. Each value is a comma-separated list of font names
 # to be used. The entries whose key ends in ".display" is used as
@@ -246,23 +242,6 @@ fontFamilyBase10.display = Terminal
 fontFamilyBase11.display = Modern
 fontFamilyBase12.display = Wide
 fontFamilyBase13.display = ###
-
-# TODO: Should we expose the base font families for translation?
-#L10N_IGNORE_BLOCK_BEGIN
-fontFamilyBase1.css = arial, helvetica, sans-serif
-fontFamilyBase2.css = 'times new roman', 'new york', times, serif
-fontFamilyBase3.css = 'arial black','avant garde'
-fontFamilyBase4.css = 'courier new', courier, monaco, monospace, sans-serif
-fontFamilyBase5.css = 'comic sans ms', 'comic sans', sans-serif
-fontFamilyBase6.css = 'lucida console', sans-serif
-fontFamilyBase7.css = garamond, 'new york', times, serif
-fontFamilyBase8.css = georgia,serif
-fontFamilyBase9.css = tahoma, 'new york', times, serif
-fontFamilyBase10.css = terminal,monaco
-fontFamilyBase11.css = 'trebuchet ms',sans-serif
-fontFamilyBase12.css = verdana, helvetica, sans-serif
-fontFamilyBase13.css = ###
-#L10N_IGNORE_BLOCK_END
 
 # These will be set by the various translations
 fontFamilyIntl1.display = ###

--- a/WebRoot/messages/AjxMsg_it.properties
+++ b/WebRoot/messages/AjxMsg_it.properties
@@ -207,10 +207,6 @@ sizeBytes = B
 # For formatting file sizes (e.g. "123.4 MB")
 formatSizeAndUnits = {0} {1}
 
-#L10N_IGNORE_BLOCK_BEGIN
-fontSizes = 8pt 9pt 10pt 11pt 12pt 13pt 14pt 16pt 18pt 24pt 36pt 48pt
-#L10N_IGNORE_BLOCK_END
-
 # The font family options specified below are a list of fonts for
 # HTML compose. Each value is a comma-separated list of font names
 # to be used. The entries whose key ends in ".display" is used as
@@ -246,23 +242,6 @@ fontFamilyBase10.display = Terminal
 fontFamilyBase11.display = Modern
 fontFamilyBase12.display = Wide
 fontFamilyBase13.display = ###
-
-# TODO: Should we expose the base font families for translation?
-#L10N_IGNORE_BLOCK_BEGIN
-fontFamilyBase1.css = arial, helvetica, sans-serif
-fontFamilyBase2.css = 'times new roman', 'new york', times, serif
-fontFamilyBase3.css = 'arial black','avant garde'
-fontFamilyBase4.css = 'courier new', courier, monaco, monospace, sans-serif
-fontFamilyBase5.css = 'comic sans ms', 'comic sans', sans-serif
-fontFamilyBase6.css = 'lucida console', sans-serif
-fontFamilyBase7.css = garamond, 'new york', times, serif
-fontFamilyBase8.css = georgia,serif
-fontFamilyBase9.css = tahoma, 'new york', times, serif
-fontFamilyBase10.css = terminal,monaco
-fontFamilyBase11.css = 'trebuchet ms',sans-serif
-fontFamilyBase12.css = verdana, helvetica, sans-serif
-fontFamilyBase13.css = ###
-#L10N_IGNORE_BLOCK_END
 
 # These will be set by the various translations
 fontFamilyIntl1.display = ###

--- a/WebRoot/messages/AjxMsg_iw.properties
+++ b/WebRoot/messages/AjxMsg_iw.properties
@@ -207,10 +207,6 @@ sizeBytes = B\u200f
 # For formatting file sizes (e.g. "123.4 MB")
 formatSizeAndUnits = {0} {1}
 
-#L10N_IGNORE_BLOCK_BEGIN
-fontSizes = 8pt 9pt 10pt 11pt 12pt 13pt 14pt 16pt 18pt 24pt 36pt 48pt
-#L10N_IGNORE_BLOCK_END
-
 # The font family options specified below are a list of fonts for
 # HTML compose. Each value is a comma-separated list of font names
 # to be used. The entries whose key ends in ".display" is used as
@@ -246,23 +242,6 @@ fontFamilyBase10.display = \u05de\u05e1\u05d5\u05e3
 fontFamilyBase11.display = \u05de\u05d5\u05d3\u05e8\u05e0\u05d9
 fontFamilyBase12.display = \u05e8\u05d7\u05d1
 fontFamilyBase13.display = ###
-
-# TODO: Should we expose the base font families for translation?
-#L10N_IGNORE_BLOCK_BEGIN
-fontFamilyBase1.css = arial, helvetica, sans-serif
-fontFamilyBase2.css = 'times new roman', 'new york', times, serif
-fontFamilyBase3.css = 'arial black','avant garde'
-fontFamilyBase4.css = 'courier new', courier, monaco, monospace, sans-serif
-fontFamilyBase5.css = 'comic sans ms', 'comic sans', sans-serif
-fontFamilyBase6.css = 'lucida console', sans-serif
-fontFamilyBase7.css = garamond, 'new york', times, serif
-fontFamilyBase8.css = georgia,serif
-fontFamilyBase9.css = tahoma, 'new york', times, serif
-fontFamilyBase10.css = terminal,monaco
-fontFamilyBase11.css = 'trebuchet ms',sans-serif
-fontFamilyBase12.css = verdana, helvetica, sans-serif
-fontFamilyBase13.css = ###
-#L10N_IGNORE_BLOCK_END
 
 # These will be set by the various translations
 fontFamilyIntl1.display = ###

--- a/WebRoot/messages/AjxMsg_ja.properties
+++ b/WebRoot/messages/AjxMsg_ja.properties
@@ -207,10 +207,6 @@ sizeBytes = B
 # For formatting file sizes (e.g. "123.4 MB")
 formatSizeAndUnits = {0} {1}
 
-#L10N_IGNORE_BLOCK_BEGIN
-fontSizes = 8pt 9pt 10pt 11pt 12pt 13pt 14pt 16pt 18pt 24pt 36pt 48pt
-#L10N_IGNORE_BLOCK_END
-
 # The font family options specified below are a list of fonts for
 # HTML compose. Each value is a comma-separated list of font names
 # to be used. The entries whose key ends in ".display" is used as
@@ -246,23 +242,6 @@ fontFamilyBase10.display = Terminal
 fontFamilyBase11.display = Modern
 fontFamilyBase12.display = Wide
 fontFamilyBase13.display = ###
-
-# TODO: Should we expose the base font families for translation?
-#L10N_IGNORE_BLOCK_BEGIN
-fontFamilyBase1.css = arial, helvetica, sans-serif
-fontFamilyBase2.css = 'times new roman', 'new york', times, serif
-fontFamilyBase3.css = 'arial black','avant garde'
-fontFamilyBase4.css = 'courier new', courier, monaco, monospace, sans-serif
-fontFamilyBase5.css = 'comic sans ms', 'comic sans', sans-serif
-fontFamilyBase6.css = 'lucida console', sans-serif
-fontFamilyBase7.css = garamond, 'new york', times, serif
-fontFamilyBase8.css = georgia,serif
-fontFamilyBase9.css = tahoma, 'new york', times, serif
-fontFamilyBase10.css = terminal,monaco
-fontFamilyBase11.css = 'trebuchet ms',sans-serif
-fontFamilyBase12.css = verdana, helvetica, sans-serif
-fontFamilyBase13.css = ###
-#L10N_IGNORE_BLOCK_END
 
 # These will be set by the various translations
 fontFamilyIntl1.display = MS P \u30b4\u30b7\u30c3\u30af

--- a/WebRoot/messages/AjxMsg_ko.properties
+++ b/WebRoot/messages/AjxMsg_ko.properties
@@ -207,10 +207,6 @@ sizeBytes = B
 # For formatting file sizes (e.g. "123.4 MB")
 formatSizeAndUnits = {0} {1}
 
-#L10N_IGNORE_BLOCK_BEGIN
-fontSizes = 8pt 9pt 10pt 11pt 12pt 13pt 14pt 16pt 18pt 24pt 36pt 48pt
-#L10N_IGNORE_BLOCK_END
-
 # The font family options specified below are a list of fonts for
 # HTML compose. Each value is a comma-separated list of font names
 # to be used. The entries whose key ends in ".display" is used as
@@ -246,23 +242,6 @@ fontFamilyBase10.display = Terminal
 fontFamilyBase11.display = Modern
 fontFamilyBase12.display = Wide
 fontFamilyBase13.display = ###
-
-# TODO: Should we expose the base font families for translation?
-#L10N_IGNORE_BLOCK_BEGIN
-fontFamilyBase1.css = arial, helvetica, sans-serif
-fontFamilyBase2.css = 'times new roman', 'new york', times, serif
-fontFamilyBase3.css = 'arial black','avant garde'
-fontFamilyBase4.css = 'courier new', courier, monaco, monospace, sans-serif
-fontFamilyBase5.css = 'comic sans ms', 'comic sans', sans-serif
-fontFamilyBase6.css = 'lucida console', sans-serif
-fontFamilyBase7.css = garamond, 'new york', times, serif
-fontFamilyBase8.css = georgia,serif
-fontFamilyBase9.css = tahoma, 'new york', times, serif
-fontFamilyBase10.css = terminal,monaco
-fontFamilyBase11.css = 'trebuchet ms',sans-serif
-fontFamilyBase12.css = verdana, helvetica, sans-serif
-fontFamilyBase13.css = ###
-#L10N_IGNORE_BLOCK_END
 
 # These will be set by the various translations
 fontFamilyIntl1.display = \uad74\ub9bc

--- a/WebRoot/messages/AjxMsg_lo.properties
+++ b/WebRoot/messages/AjxMsg_lo.properties
@@ -207,10 +207,6 @@ sizeBytes = B
 # For formatting file sizes (e.g. "123.4 MB")
 formatSizeAndUnits = {0} {1}
 
-#L10N_IGNORE_BLOCK_BEGIN
-fontSizes = 8pt 9pt 10pt 11pt 12pt 13pt 14pt 16pt 18pt 24pt 36pt 48pt
-#L10N_IGNORE_BLOCK_END
-
 # The font family options specified below are a list of fonts for
 # HTML compose. Each value is a comma-separated list of font names
 # to be used. The entries whose key ends in ".display" is used as
@@ -246,23 +242,6 @@ fontFamilyBase10.display = \u0e9b\u0eb2\u0e8d
 fontFamilyBase11.display = \u0e97\u0eb1\u0e99\u0eaa\u0eb0\u0ec4\u0edd
 fontFamilyBase12.display = \u0e81\u0ec9\u0ea7\u0eb2\u0e87
 fontFamilyBase13.display = ###
-
-# TODO: Should we expose the base font families for translation?
-#L10N_IGNORE_BLOCK_BEGIN
-fontFamilyBase1.css = arial, helvetica, sans-serif
-fontFamilyBase2.css = 'times new roman', 'new york', times, serif
-fontFamilyBase3.css = 'arial black','avant garde'
-fontFamilyBase4.css = 'courier new', courier, monaco, monospace, sans-serif
-fontFamilyBase5.css = 'comic sans ms', 'comic sans', sans-serif
-fontFamilyBase6.css = 'lucida console', sans-serif
-fontFamilyBase7.css = garamond, 'new york', times, serif
-fontFamilyBase8.css = georgia,serif
-fontFamilyBase9.css = tahoma, 'new york', times, serif
-fontFamilyBase10.css = terminal,monaco
-fontFamilyBase11.css = 'trebuchet ms',sans-serif
-fontFamilyBase12.css = verdana, helvetica, sans-serif
-fontFamilyBase13.css = ###
-#L10N_IGNORE_BLOCK_END
 
 # These will be set by the various translations
 fontFamilyIntl1.display = ###

--- a/WebRoot/messages/AjxMsg_ms.properties
+++ b/WebRoot/messages/AjxMsg_ms.properties
@@ -207,10 +207,6 @@ sizeBytes = B
 # For formatting file sizes (e.g. "123.4 MB")
 formatSizeAndUnits = {0} {1}
 
-#L10N_IGNORE_BLOCK_BEGIN
-fontSizes = 8pt 9pt 10pt 11pt 12pt 13pt 14pt 16pt 18pt 24pt 36pt 48pt
-#L10N_IGNORE_BLOCK_END
-
 # The font family options specified below are a list of fonts for
 # HTML compose. Each value is a comma-separated list of font names
 # to be used. The entries whose key ends in ".display" is used as
@@ -246,23 +242,6 @@ fontFamilyBase10.display = Terminal
 fontFamilyBase11.display = Modern
 fontFamilyBase12.display = Wide
 fontFamilyBase13.display = ###
-
-# TODO: Should we expose the base font families for translation?
-#L10N_IGNORE_BLOCK_BEGIN
-fontFamilyBase1.css = arial, helvetica, sans-serif
-fontFamilyBase2.css = 'times new roman', 'new york', times, serif
-fontFamilyBase3.css = 'arial black','avant garde'
-fontFamilyBase4.css = 'courier new', courier, monaco, monospace, sans-serif
-fontFamilyBase5.css = 'comic sans ms', 'comic sans', sans-serif
-fontFamilyBase6.css = 'lucida console', sans-serif
-fontFamilyBase7.css = garamond, 'new york', times, serif
-fontFamilyBase8.css = georgia,serif
-fontFamilyBase9.css = tahoma, 'new york', times, serif
-fontFamilyBase10.css = terminal,monaco
-fontFamilyBase11.css = 'trebuchet ms',sans-serif
-fontFamilyBase12.css = verdana, helvetica, sans-serif
-fontFamilyBase13.css = ###
-#L10N_IGNORE_BLOCK_END
 
 # These will be set by the various translations
 fontFamilyIntl1.display = ###

--- a/WebRoot/messages/AjxMsg_nl.properties
+++ b/WebRoot/messages/AjxMsg_nl.properties
@@ -207,10 +207,6 @@ sizeBytes = B
 # For formatting file sizes (e.g. "123.4 MB")
 formatSizeAndUnits = {0} {1}
 
-#L10N_IGNORE_BLOCK_BEGIN
-fontSizes = 8pt 9pt 10pt 11pt 12pt 13pt 14pt 16pt 18pt 24pt 36pt 48pt
-#L10N_IGNORE_BLOCK_END
-
 # The font family options specified below are a list of fonts for
 # HTML compose. Each value is a comma-separated list of font names
 # to be used. The entries whose key ends in ".display" is used as
@@ -246,23 +242,6 @@ fontFamilyBase10.display = Terminal
 fontFamilyBase11.display = Modern
 fontFamilyBase12.display = Wide
 fontFamilyBase13.display = ###
-
-# TODO: Should we expose the base font families for translation?
-#L10N_IGNORE_BLOCK_BEGIN
-fontFamilyBase1.css = arial, helvetica, sans-serif
-fontFamilyBase2.css = 'times new roman', 'new york', times, serif
-fontFamilyBase3.css = 'arial black','avant garde'
-fontFamilyBase4.css = 'courier new', courier, monaco, monospace, sans-serif
-fontFamilyBase5.css = 'comic sans ms', 'comic sans', sans-serif
-fontFamilyBase6.css = 'lucida console', sans-serif
-fontFamilyBase7.css = garamond, 'new york', times, serif
-fontFamilyBase8.css = georgia,serif
-fontFamilyBase9.css = tahoma, 'new york', times, serif
-fontFamilyBase10.css = terminal,monaco
-fontFamilyBase11.css = 'trebuchet ms',sans-serif
-fontFamilyBase12.css = verdana, helvetica, sans-serif
-fontFamilyBase13.css = ###
-#L10N_IGNORE_BLOCK_END
 
 # These will be set by the various translations
 fontFamilyIntl1.display = ###

--- a/WebRoot/messages/AjxMsg_no.properties
+++ b/WebRoot/messages/AjxMsg_no.properties
@@ -207,10 +207,6 @@ sizeBytes     = B
 # For formatting file sizes (e.g. "123.4 MB")
 formatSizeAndUnits = {0} {1}
 
-#L10N_IGNORE_BLOCK_BEGIN
-fontSizes = 8pt 9pt 10pt 11pt 12pt 13pt 14pt 16pt 18pt 24pt 36pt 48pt
-#L10N_IGNORE_BLOCK_END
-
 # The font family options specified below are a list of fonts for
 # HTML compose. Each value is a comma-separated list of font names
 # to be used. The entries whose key ends in ".display" is used as
@@ -246,23 +242,6 @@ fontFamilyBase10.display = Terminal
 fontFamilyBase11.display = Modern
 fontFamilyBase12.display = Wide
 fontFamilyBase13.display = ###
-
-# TODO: Should we expose the base font families for translation?
-#L10N_IGNORE_BLOCK_BEGIN
-fontFamilyBase1.css = arial, helvetica, sans-serif
-fontFamilyBase2.css = 'times new roman', 'new york', times, serif
-fontFamilyBase3.css = 'arial black','avant garde'
-fontFamilyBase4.css = 'courier new', courier, monaco, monospace, sans-serif
-fontFamilyBase5.css = 'comic sans ms', 'comic sans', sans-serif
-fontFamilyBase6.css = 'lucida console', sans-serif
-fontFamilyBase7.css = garamond, 'new york', times, serif
-fontFamilyBase8.css = georgia,serif
-fontFamilyBase9.css = tahoma, 'new york', times, serif
-fontFamilyBase10.css = terminal,monaco
-fontFamilyBase11.css = 'trebuchet ms',sans-serif
-fontFamilyBase12.css = verdana, helvetica, sans-serif
-fontFamilyBase13.css = ###
-#L10N_IGNORE_BLOCK_END
 
 # These will be set by the various translations
 fontFamilyIntl1.display = ###

--- a/WebRoot/messages/AjxMsg_pl.properties
+++ b/WebRoot/messages/AjxMsg_pl.properties
@@ -207,10 +207,6 @@ sizeBytes = B
 # For formatting file sizes (e.g. "123.4 MB")
 formatSizeAndUnits = {0} {1}
 
-#L10N_IGNORE_BLOCK_BEGIN
-fontSizes = 8pt 9pt 10pt 11pt 12pt 13pt 14pt 16pt 18pt 24pt 36pt 48pt
-#L10N_IGNORE_BLOCK_END
-
 # The font family options specified below are a list of fonts for
 # HTML compose. Each value is a comma-separated list of font names
 # to be used. The entries whose key ends in ".display" is used as
@@ -246,23 +242,6 @@ fontFamilyBase10.display = Terminal
 fontFamilyBase11.display = Modern
 fontFamilyBase12.display = Wide
 fontFamilyBase13.display = ###
-
-# TODO: Should we expose the base font families for translation?
-#L10N_IGNORE_BLOCK_BEGIN
-fontFamilyBase1.css = arial, helvetica, sans-serif
-fontFamilyBase2.css = 'times new roman', 'new york', times, serif
-fontFamilyBase3.css = 'arial black','avant garde'
-fontFamilyBase4.css = 'courier new', courier, monaco, monospace, sans-serif
-fontFamilyBase5.css = 'comic sans ms', 'comic sans', sans-serif
-fontFamilyBase6.css = 'lucida console', sans-serif
-fontFamilyBase7.css = garamond, 'new york', times, serif
-fontFamilyBase8.css = georgia,serif
-fontFamilyBase9.css = tahoma, 'new york', times, serif
-fontFamilyBase10.css = terminal,monaco
-fontFamilyBase11.css = 'trebuchet ms',sans-serif
-fontFamilyBase12.css = verdana, helvetica, sans-serif
-fontFamilyBase13.css = ###
-#L10N_IGNORE_BLOCK_END
 
 # These will be set by the various translations
 fontFamilyIntl1.display = ###

--- a/WebRoot/messages/AjxMsg_pt.properties
+++ b/WebRoot/messages/AjxMsg_pt.properties
@@ -208,10 +208,6 @@ sizeBytes     = B
 # For formatting file sizes (e.g. "123.4 MB")
 formatSizeAndUnits = {0} {1}
 
-#L10N_IGNORE_BLOCK_BEGIN
-fontSizes = 8pt 9pt 10pt 11pt 12pt 13pt 14pt 16pt 18pt 24pt 36pt 48pt
-#L10N_IGNORE_BLOCK_END
-
 # The font family options specified below are a list of fonts for
 # HTML compose. Each value is a comma-separated list of font names
 # to be used. The entries whose key ends in ".display" is used as
@@ -247,23 +243,6 @@ fontFamilyBase10.display = Terminal
 fontFamilyBase11.display = Moderno
 fontFamilyBase12.display = Largo
 fontFamilyBase13.display = ###
-
-# TODO: Should we expose the base font families for translation?
-#L10N_IGNORE_BLOCK_BEGIN
-fontFamilyBase1.css = arial, helvetica, sans-serif
-fontFamilyBase2.css = 'times new roman', 'new york', times, serif
-fontFamilyBase3.css = 'arial black','avant garde'
-fontFamilyBase4.css = 'courier new', courier, monaco, monospace, sans-serif
-fontFamilyBase5.css = 'comic sans ms', 'comic sans', sans-serif
-fontFamilyBase6.css = 'lucida console', sans-serif
-fontFamilyBase7.css = garamond, 'new york', times, serif
-fontFamilyBase8.css = georgia,serif
-fontFamilyBase9.css = tahoma, 'new york', times, serif
-fontFamilyBase10.css = terminal,monaco
-fontFamilyBase11.css = 'trebuchet ms',sans-serif
-fontFamilyBase12.css = verdana, helvetica, sans-serif
-fontFamilyBase13.css = ###
-#L10N_IGNORE_BLOCK_END
 
 # These will be set by the various translations
 fontFamilyIntl1.display = ###

--- a/WebRoot/messages/AjxMsg_pt_BR.properties
+++ b/WebRoot/messages/AjxMsg_pt_BR.properties
@@ -207,10 +207,6 @@ sizeBytes = B
 # For formatting file sizes (e.g. "123.4 MB")
 formatSizeAndUnits = {0} {1}
 
-#L10N_IGNORE_BLOCK_BEGIN
-fontSizes = 8pt 9pt 10pt 11pt 12pt 13pt 14pt 16pt 18pt 24pt 36pt 48pt
-#L10N_IGNORE_BLOCK_END
-
 # The font family options specified below are a list of fonts for
 # HTML compose. Each value is a comma-separated list of font names
 # to be used. The entries whose key ends in ".display" is used as
@@ -246,23 +242,6 @@ fontFamilyBase10.display = Terminal
 fontFamilyBase11.display = Modern
 fontFamilyBase12.display = Wide
 fontFamilyBase13.display = ###
-
-# TODO: Should we expose the base font families for translation?
-#L10N_IGNORE_BLOCK_BEGIN
-fontFamilyBase1.css = arial, helvetica, sans-serif
-fontFamilyBase2.css = 'times new roman', 'new york', times, serif
-fontFamilyBase3.css = 'arial black','avant garde'
-fontFamilyBase4.css = 'courier new', courier, monaco, monospace, sans-serif
-fontFamilyBase5.css = 'comic sans ms', 'comic sans', sans-serif
-fontFamilyBase6.css = 'lucida console', sans-serif
-fontFamilyBase7.css = garamond, 'new york', times, serif
-fontFamilyBase8.css = georgia,serif
-fontFamilyBase9.css = tahoma, 'new york', times, serif
-fontFamilyBase10.css = terminal,monaco
-fontFamilyBase11.css = 'trebuchet ms',sans-serif
-fontFamilyBase12.css = verdana, helvetica, sans-serif
-fontFamilyBase13.css = ###
-#L10N_IGNORE_BLOCK_END
 
 # These will be set by the various translations
 fontFamilyIntl1.display = ###

--- a/WebRoot/messages/AjxMsg_ro.properties
+++ b/WebRoot/messages/AjxMsg_ro.properties
@@ -207,10 +207,6 @@ sizeBytes = B
 # For formatting file sizes (e.g. "123.4 MB")
 formatSizeAndUnits = {0} {1}
 
-#L10N_IGNORE_BLOCK_BEGIN
-fontSizes = 8pt 9pt 10pt 11pt 12pt 13pt 14pt 16pt 18pt 24pt 36pt 48pt
-#L10N_IGNORE_BLOCK_END
-
 # The font family options specified below are a list of fonts for
 # HTML compose. Each value is a comma-separated list of font names
 # to be used. The entries whose key ends in ".display" is used as
@@ -246,23 +242,6 @@ fontFamilyBase10.display = Terminal
 fontFamilyBase11.display = Modern
 fontFamilyBase12.display = Wide
 fontFamilyBase13.display = ###
-
-# TODO: Should we expose the base font families for translation?
-#L10N_IGNORE_BLOCK_BEGIN
-fontFamilyBase1.css = arial, helvetica, sans-serif
-fontFamilyBase2.css = 'times new roman', 'new york', times, serif
-fontFamilyBase3.css = 'arial black','avant garde'
-fontFamilyBase4.css = 'courier new', courier, monaco, monospace, sans-serif
-fontFamilyBase5.css = 'comic sans ms', 'comic sans', sans-serif
-fontFamilyBase6.css = 'lucida console', sans-serif
-fontFamilyBase7.css = garamond, 'new york', times, serif
-fontFamilyBase8.css = georgia,serif
-fontFamilyBase9.css = tahoma, 'new york', times, serif
-fontFamilyBase10.css = terminal,monaco
-fontFamilyBase11.css = 'trebuchet ms',sans-serif
-fontFamilyBase12.css = verdana, helvetica, sans-serif
-fontFamilyBase13.css = ###
-#L10N_IGNORE_BLOCK_END
 
 # These will be set by the various translations
 fontFamilyIntl1.display = ###

--- a/WebRoot/messages/AjxMsg_ru.properties
+++ b/WebRoot/messages/AjxMsg_ru.properties
@@ -207,10 +207,6 @@ sizeBytes = \u0411
 # For formatting file sizes (e.g. "123.4 MB")
 formatSizeAndUnits = {0} {1}
 
-#L10N_IGNORE_BLOCK_BEGIN
-fontSizes = 8pt 9pt 10pt 11pt 12pt 13pt 14pt 16pt 18pt 24pt 36pt 48pt
-#L10N_IGNORE_BLOCK_END
-
 # The font family options specified below are a list of fonts for
 # HTML compose. Each value is a comma-separated list of font names
 # to be used. The entries whose key ends in ".display" is used as
@@ -246,23 +242,6 @@ fontFamilyBase10.display = Terminal
 fontFamilyBase11.display = Modern
 fontFamilyBase12.display = Wide
 fontFamilyBase13.display = ###
-
-# TODO: Should we expose the base font families for translation?
-#L10N_IGNORE_BLOCK_BEGIN
-fontFamilyBase1.css = arial, helvetica, sans-serif
-fontFamilyBase2.css = 'times new roman', 'new york', times, serif
-fontFamilyBase3.css = 'arial black','avant garde'
-fontFamilyBase4.css = 'courier new', courier, monaco, monospace, sans-serif
-fontFamilyBase5.css = 'comic sans ms', 'comic sans', sans-serif
-fontFamilyBase6.css = 'lucida console', sans-serif
-fontFamilyBase7.css = garamond, 'new york', times, serif
-fontFamilyBase8.css = georgia,serif
-fontFamilyBase9.css = tahoma, 'new york', times, serif
-fontFamilyBase10.css = terminal,monaco
-fontFamilyBase11.css = 'trebuchet ms',sans-serif
-fontFamilyBase12.css = verdana, helvetica, sans-serif
-fontFamilyBase13.css = ###
-#L10N_IGNORE_BLOCK_END
 
 # These will be set by the various translations
 fontFamilyIntl1.display = ###

--- a/WebRoot/messages/AjxMsg_sl.properties
+++ b/WebRoot/messages/AjxMsg_sl.properties
@@ -207,10 +207,6 @@ sizeBytes = B
 # For formatting file sizes (e.g. "123.4 MB")
 formatSizeAndUnits = {0} {1}
 
-#L10N_IGNORE_BLOCK_BEGIN
-fontSizes = 8pt 9pt 10pt 11pt 12pt 13pt 14pt 16pt 18pt 24pt 36pt 48pt
-#L10N_IGNORE_BLOCK_END
-
 # The font family options specified below are a list of fonts for
 # HTML compose. Each value is a comma-separated list of font names
 # to be used. The entries whose key ends in ".display" is used as
@@ -246,23 +242,6 @@ fontFamilyBase10.display = Terminal
 fontFamilyBase11.display = Modern
 fontFamilyBase12.display = Wide
 fontFamilyBase13.display = ###
-
-# TODO: Should we expose the base font families for translation?
-#L10N_IGNORE_BLOCK_BEGIN
-fontFamilyBase1.css = arial, helvetica, sans-serif
-fontFamilyBase2.css = 'times new roman', 'new york', times, serif
-fontFamilyBase3.css = 'arial black','avant garde'
-fontFamilyBase4.css = 'courier new', courier, monaco, monospace, sans-serif
-fontFamilyBase5.css = 'comic sans ms', 'comic sans', sans-serif
-fontFamilyBase6.css = 'lucida console', sans-serif
-fontFamilyBase7.css = garamond, 'new york', times, serif
-fontFamilyBase8.css = georgia,serif
-fontFamilyBase9.css = tahoma, 'new york', times, serif
-fontFamilyBase10.css = terminal,monaco
-fontFamilyBase11.css = 'trebuchet ms',sans-serif
-fontFamilyBase12.css = verdana, helvetica, sans-serif
-fontFamilyBase13.css = ###
-#L10N_IGNORE_BLOCK_END
 
 # These will be set by the various translations
 fontFamilyIntl1.display = ###

--- a/WebRoot/messages/AjxMsg_sv.properties
+++ b/WebRoot/messages/AjxMsg_sv.properties
@@ -207,10 +207,6 @@ sizeBytes = byte
 # For formatting file sizes (e.g. "123.4 MB")
 formatSizeAndUnits = {0} {1}
 
-#L10N_IGNORE_BLOCK_BEGIN
-fontSizes = 8pt 9pt 10pt 11pt 12pt 13pt 14pt 16pt 18pt 24pt 36pt 48pt
-#L10N_IGNORE_BLOCK_END
-
 # The font family options specified below are a list of fonts for
 # HTML compose. Each value is a comma-separated list of font names
 # to be used. The entries whose key ends in ".display" is used as
@@ -246,23 +242,6 @@ fontFamilyBase10.display = Terminal
 fontFamilyBase11.display = Modern
 fontFamilyBase12.display = Wide
 fontFamilyBase13.display = ###
-
-# TODO: Should we expose the base font families for translation?
-#L10N_IGNORE_BLOCK_BEGIN
-fontFamilyBase1.css = arial, helvetica, sans-serif
-fontFamilyBase2.css = 'times new roman', 'new york', times, serif
-fontFamilyBase3.css = 'arial black','avant garde'
-fontFamilyBase4.css = 'courier new', courier, monaco, monospace, sans-serif
-fontFamilyBase5.css = 'comic sans ms', 'comic sans', sans-serif
-fontFamilyBase6.css = 'lucida console', sans-serif
-fontFamilyBase7.css = garamond, 'new york', times, serif
-fontFamilyBase8.css = georgia,serif
-fontFamilyBase9.css = tahoma, 'new york', times, serif
-fontFamilyBase10.css = terminal,monaco
-fontFamilyBase11.css = 'trebuchet ms',sans-serif
-fontFamilyBase12.css = verdana, helvetica, sans-serif
-fontFamilyBase13.css = ###
-#L10N_IGNORE_BLOCK_END
 
 # These will be set by the various translations
 fontFamilyIntl1.display = ###

--- a/WebRoot/messages/AjxMsg_th.properties
+++ b/WebRoot/messages/AjxMsg_th.properties
@@ -207,10 +207,6 @@ sizeBytes = B
 # For formatting file sizes (e.g. "123.4 MB")
 formatSizeAndUnits = {0} {1}
 
-#L10N_IGNORE_BLOCK_BEGIN
-fontSizes = 8pt 9pt 10pt 11pt 12pt 13pt 14pt 16pt 18pt 24pt 36pt 48pt
-#L10N_IGNORE_BLOCK_END
-
 # The font family options specified below are a list of fonts for
 # HTML compose. Each value is a comma-separated list of font names
 # to be used. The entries whose key ends in ".display" is used as
@@ -246,23 +242,6 @@ fontFamilyBase10.display = Terminal
 fontFamilyBase11.display = Modern
 fontFamilyBase12.display = Wide
 fontFamilyBase13.display = ###
-
-# TODO: Should we expose the base font families for translation?
-#L10N_IGNORE_BLOCK_BEGIN
-fontFamilyBase1.css = arial, helvetica, sans-serif
-fontFamilyBase2.css = 'times new roman', 'new york', times, serif
-fontFamilyBase3.css = 'arial black','avant garde'
-fontFamilyBase4.css = 'courier new', courier, monaco, monospace, sans-serif
-fontFamilyBase5.css = 'comic sans ms', 'comic sans', sans-serif
-fontFamilyBase6.css = 'lucida console', sans-serif
-fontFamilyBase7.css = garamond, 'new york', times, serif
-fontFamilyBase8.css = georgia,serif
-fontFamilyBase9.css = tahoma, 'new york', times, serif
-fontFamilyBase10.css = terminal,monaco
-fontFamilyBase11.css = 'trebuchet ms',sans-serif
-fontFamilyBase12.css = verdana, helvetica, sans-serif
-fontFamilyBase13.css = ###
-#L10N_IGNORE_BLOCK_END
 
 # These will be set by the various translations
 fontFamilyIntl1.display = ###

--- a/WebRoot/messages/AjxMsg_tr.properties
+++ b/WebRoot/messages/AjxMsg_tr.properties
@@ -207,10 +207,6 @@ sizeBytes = B
 # For formatting file sizes (e.g. "123.4 MB")
 formatSizeAndUnits = {0} {1}
 
-#L10N_IGNORE_BLOCK_BEGIN
-fontSizes = 8pt 9pt 10pt 11pt 12pt 13pt 14pt 16pt 18pt 24pt 36pt 48pt
-#L10N_IGNORE_BLOCK_END
-
 # The font family options specified below are a list of fonts for
 # HTML compose. Each value is a comma-separated list of font names
 # to be used. The entries whose key ends in ".display" is used as
@@ -246,23 +242,6 @@ fontFamilyBase10.display = Terminal
 fontFamilyBase11.display = Modern
 fontFamilyBase12.display = Wide
 fontFamilyBase13.display = ###
-
-# TODO: Should we expose the base font families for translation?
-#L10N_IGNORE_BLOCK_BEGIN
-fontFamilyBase1.css = arial, helvetica, sans-serif
-fontFamilyBase2.css = 'times new roman', 'new york', times, serif
-fontFamilyBase3.css = 'arial black','avant garde'
-fontFamilyBase4.css = 'courier new', courier, monaco, monospace, sans-serif
-fontFamilyBase5.css = 'comic sans ms', 'comic sans', sans-serif
-fontFamilyBase6.css = 'lucida console', sans-serif
-fontFamilyBase7.css = garamond, 'new york', times, serif
-fontFamilyBase8.css = georgia,serif
-fontFamilyBase9.css = tahoma, 'new york', times, serif
-fontFamilyBase10.css = terminal,monaco
-fontFamilyBase11.css = 'trebuchet ms',sans-serif
-fontFamilyBase12.css = verdana, helvetica, sans-serif
-fontFamilyBase13.css = ###
-#L10N_IGNORE_BLOCK_END
 
 # These will be set by the various translations
 fontFamilyIntl1.display = ###

--- a/WebRoot/messages/AjxMsg_uk.properties
+++ b/WebRoot/messages/AjxMsg_uk.properties
@@ -207,10 +207,6 @@ sizeBytes = \u0411\u0430\u0439\u0442
 # For formatting file sizes (e.g. "123.4 MB")
 formatSizeAndUnits = {0} {1}
 
-#L10N_IGNORE_BLOCK_BEGIN
-fontSizes = 8pt 9pt 10pt 11pt 12pt 13pt 14pt 16pt 18pt 24pt 36pt 48pt
-#L10N_IGNORE_BLOCK_END
-
 # The font family options specified below are a list of fonts for
 # HTML compose. Each value is a comma-separated list of font names
 # to be used. The entries whose key ends in ".display" is used as
@@ -246,23 +242,6 @@ fontFamilyBase10.display = Terminal
 fontFamilyBase11.display = Modern
 fontFamilyBase12.display = Wide
 fontFamilyBase13.display = ###
-
-# TODO: Should we expose the base font families for translation?
-#L10N_IGNORE_BLOCK_BEGIN
-fontFamilyBase1.css = arial, helvetica, sans-serif
-fontFamilyBase2.css = 'times new roman', 'new york', times, serif
-fontFamilyBase3.css = 'arial black','avant garde'
-fontFamilyBase4.css = 'courier new', courier, monaco, monospace, sans-serif
-fontFamilyBase5.css = 'comic sans ms', 'comic sans', sans-serif
-fontFamilyBase6.css = 'lucida console', sans-serif
-fontFamilyBase7.css = garamond, 'new york', times, serif
-fontFamilyBase8.css = georgia,serif
-fontFamilyBase9.css = tahoma, 'new york', times, serif
-fontFamilyBase10.css = terminal,monaco
-fontFamilyBase11.css = 'trebuchet ms',sans-serif
-fontFamilyBase12.css = verdana, helvetica, sans-serif
-fontFamilyBase13.css = ###
-#L10N_IGNORE_BLOCK_END
 
 # These will be set by the various translations
 fontFamilyIntl1.display = ###

--- a/WebRoot/messages/AjxMsg_vi.properties
+++ b/WebRoot/messages/AjxMsg_vi.properties
@@ -208,10 +208,6 @@ sizeBytes     = B
 # For formatting file sizes (e.g. "123.4 MB")
 formatSizeAndUnits = {0} {1}
 
-#L10N_IGNORE_BLOCK_BEGIN
-fontSizes = 8pt 9pt 10pt 11pt 12pt 13pt 14pt 16pt 18pt 24pt 36pt 48pt
-#L10N_IGNORE_BLOCK_END
-
 # The font family options specified below are a list of fonts for
 # HTML compose. Each value is a comma-separated list of font names
 # to be used. The entries whose key ends in ".display" is used as
@@ -247,23 +243,6 @@ fontFamilyBase10.display = Terminal
 fontFamilyBase11.display = Modern
 fontFamilyBase12.display = Wide
 fontFamilyBase13.display = ###
-
-# TODO: Should we expose the base font families for translation?
-#L10N_IGNORE_BLOCK_BEGIN
-fontFamilyBase1.css = arial, helvetica, sans-serif
-fontFamilyBase2.css = 'times new roman', 'new york', times, serif
-fontFamilyBase3.css = 'arial black','avant garde'
-fontFamilyBase4.css = 'courier new', courier, monaco, monospace, sans-serif
-fontFamilyBase5.css = 'comic sans ms', 'comic sans', sans-serif
-fontFamilyBase6.css = 'lucida console', sans-serif
-fontFamilyBase7.css = garamond, 'new york', times, serif
-fontFamilyBase8.css = georgia,serif
-fontFamilyBase9.css = tahoma, 'new york', times, serif
-fontFamilyBase10.css = terminal,monaco
-fontFamilyBase11.css = 'trebuchet ms',sans-serif
-fontFamilyBase12.css = verdana, helvetica, sans-serif
-fontFamilyBase13.css = ###
-#L10N_IGNORE_BLOCK_END
 
 # These will be set by the various translations
 fontFamilyIntl1.display = ###

--- a/WebRoot/messages/AjxMsg_zh_CN.properties
+++ b/WebRoot/messages/AjxMsg_zh_CN.properties
@@ -207,10 +207,6 @@ sizeBytes = B
 # For formatting file sizes (e.g. "123.4 MB")
 formatSizeAndUnits = {0} {1}
 
-#L10N_IGNORE_BLOCK_BEGIN
-fontSizes = 8pt 9pt 10pt 11pt 12pt 13pt 14pt 16pt 18pt 24pt 36pt 48pt
-#L10N_IGNORE_BLOCK_END
-
 # The font family options specified below are a list of fonts for
 # HTML compose. Each value is a comma-separated list of font names
 # to be used. The entries whose key ends in ".display" is used as
@@ -246,23 +242,6 @@ fontFamilyBase10.display = Terminal
 fontFamilyBase11.display = Modern
 fontFamilyBase12.display = Wide
 fontFamilyBase13.display = ###
-
-# TODO: Should we expose the base font families for translation?
-#L10N_IGNORE_BLOCK_BEGIN
-fontFamilyBase1.css = arial, helvetica, sans-serif
-fontFamilyBase2.css = 'times new roman', 'new york', times, serif
-fontFamilyBase3.css = 'arial black','avant garde'
-fontFamilyBase4.css = 'courier new', courier, monaco, monospace, sans-serif
-fontFamilyBase5.css = 'comic sans ms', 'comic sans', sans-serif
-fontFamilyBase6.css = 'lucida console', sans-serif
-fontFamilyBase7.css = garamond, 'new york', times, serif
-fontFamilyBase8.css = georgia,serif
-fontFamilyBase9.css = tahoma, 'new york', times, serif
-fontFamilyBase10.css = terminal,monaco
-fontFamilyBase11.css = 'trebuchet ms',sans-serif
-fontFamilyBase12.css = verdana, helvetica, sans-serif
-fontFamilyBase13.css = ###
-#L10N_IGNORE_BLOCK_END
 
 # These will be set by the various translations
 fontFamilyIntl1.display = \u5b8b\u4f53

--- a/WebRoot/messages/AjxMsg_zh_HK.properties
+++ b/WebRoot/messages/AjxMsg_zh_HK.properties
@@ -207,10 +207,6 @@ sizeBytes = B
 # For formatting file sizes (e.g. "123.4 MB")
 formatSizeAndUnits = {0} {1}
 
-#L10N_IGNORE_BLOCK_BEGIN
-fontSizes = 8pt 9pt 10pt 11pt 12pt 13pt 14pt 16pt 18pt 24pt 36pt 48pt
-#L10N_IGNORE_BLOCK_END
-
 # The font family options specified below are a list of fonts for
 # HTML compose. Each value is a comma-separated list of font names
 # to be used. The entries whose key ends in ".display" is used as
@@ -246,23 +242,6 @@ fontFamilyBase10.display = Terminal
 fontFamilyBase11.display = Modern
 fontFamilyBase12.display = Wide
 fontFamilyBase13.display = ###
-
-# TODO: Should we expose the base font families for translation?
-#L10N_IGNORE_BLOCK_BEGIN
-fontFamilyBase1.css = arial, helvetica, sans-serif
-fontFamilyBase2.css = 'times new roman', 'new york', times, serif
-fontFamilyBase3.css = 'arial black','avant garde'
-fontFamilyBase4.css = 'courier new', courier, monaco, monospace, sans-serif
-fontFamilyBase5.css = 'comic sans ms', 'comic sans', sans-serif
-fontFamilyBase6.css = 'lucida console', sans-serif
-fontFamilyBase7.css = garamond, 'new york', times, serif
-fontFamilyBase8.css = georgia,serif
-fontFamilyBase9.css = tahoma, 'new york', times, serif
-fontFamilyBase10.css = terminal,monaco
-fontFamilyBase11.css = 'trebuchet ms',sans-serif
-fontFamilyBase12.css = verdana, helvetica, sans-serif
-fontFamilyBase13.css = ###
-#L10N_IGNORE_BLOCK_END
 
 # These will be set by the various translations
 fontFamilyIntl1.display = \u65b0\u7d30\u660e\u9ad4

--- a/WebRoot/messages/AjxMsg_zh_TW.properties
+++ b/WebRoot/messages/AjxMsg_zh_TW.properties
@@ -207,10 +207,6 @@ sizeBytes = B
 # For formatting file sizes (e.g. "123.4 MB")
 formatSizeAndUnits = {0} {1}
 
-#L10N_IGNORE_BLOCK_BEGIN
-fontSizes = 8pt 9pt 10pt 11pt 12pt 13pt 14pt 16pt 18pt 24pt 36pt 48pt
-#L10N_IGNORE_BLOCK_END
-
 # The font family options specified below are a list of fonts for
 # HTML compose. Each value is a comma-separated list of font names
 # to be used. The entries whose key ends in ".display" is used as
@@ -246,23 +242,6 @@ fontFamilyBase10.display = Terminal
 fontFamilyBase11.display = Modern
 fontFamilyBase12.display = Wide
 fontFamilyBase13.display = ###
-
-# TODO: Should we expose the base font families for translation?
-#L10N_IGNORE_BLOCK_BEGIN
-fontFamilyBase1.css = arial, helvetica, sans-serif
-fontFamilyBase2.css = 'times new roman', 'new york', times, serif
-fontFamilyBase3.css = 'arial black','avant garde'
-fontFamilyBase4.css = 'courier new', courier, monaco, monospace, sans-serif
-fontFamilyBase5.css = 'comic sans ms', 'comic sans', sans-serif
-fontFamilyBase6.css = 'lucida console', sans-serif
-fontFamilyBase7.css = garamond, 'new york', times, serif
-fontFamilyBase8.css = georgia,serif
-fontFamilyBase9.css = tahoma, 'new york', times, serif
-fontFamilyBase10.css = terminal,monaco
-fontFamilyBase11.css = 'trebuchet ms',sans-serif
-fontFamilyBase12.css = verdana, helvetica, sans-serif
-fontFamilyBase13.css = ###
-#L10N_IGNORE_BLOCK_END
 
 # These will be set by the various translations
 fontFamilyIntl1.display = \u5b8b\u9ad4


### PR DESCRIPTION
- Make sure values passed to font-format config in tinymce doesn't contain single quotes, this upsets tinymce editor and we are seeing issues when user selects any font format, combobox gets different value
- Removed i10n ignore blocks from language files as it is not required and creates confusion