### PR TITLE
ZCS-6040: changed the way to move focus to another member of tabGroup

### DIFF
--- a/WebRoot/js/ajax/dwt/widgets/DwtForm.js
+++ b/WebRoot/js/ajax/dwt/widgets/DwtForm.js
@@ -1541,7 +1541,8 @@ DwtFormRows.prototype.removeRow = function(indexOrId) {
 
 	if (hadFocus) {
 		var otherItem = this._items[item.aka] || this._items[this._rowCount - 1];
-		otherItem.control.getTabGroupMember().focus();
+		var tabGroup = otherItem.control.getTabGroupMember();
+		tabGroup.setFocusMember(tabGroup.getFirstMember(true), true, false);
 	}
 
 	if (this._onremoverow) {


### PR DESCRIPTION
[Problem]
Script error dialog is shown when a focused field is removed in Edit Contact page.

[Root cause]
DwtTabGroup.focus function had been removed on bugzilla 99393. However, DwtForm.removeRow called it.

[Fix]
Change to call DwtTabGroup.setFocusMember instead.

[Reference]
bugzilla 99393 - Zimbra/zm-ajax@a8f090e