### PR TITLE
ZBUG-747: fixed Dwt.setLocation for Edge44

### DIFF
--- a/WebRoot/js/ajax/dwt/core/Dwt.js
+++ b/WebRoot/js/ajax/dwt/core/Dwt.js
@@ -556,7 +556,13 @@ function(htmlElement, point) {
 Dwt.setLocation =
 function(htmlElement, x, y) {
 	if (!(htmlElement = Dwt.getElement(htmlElement))) { return; }
-	var position = DwtCssStyle.getProperty(htmlElement, 'position');
+	var position;
+	if (AjxEnv.isMSEdge && AjxEnv.browserVersion > 18) {
+		position = htmlElement.style.position;
+	}
+	if (!position) {
+		position = DwtCssStyle.getProperty(htmlElement, 'position');
+	}
 	if (position != Dwt.ABSOLUTE_STYLE && position != Dwt.RELATIVE_STYLE && position != Dwt.FIXED_STYLE) {
 		DBG.println(AjxDebug.DBG1, "Cannot position static widget " + htmlElement.className);
 		throw new DwtException("Static widgets may not be positioned", DwtException.INVALID_OP, "Dwt.setLocation");


### PR DESCRIPTION
[Problem]
Ajax client doesn't work on Edge44, EdgeHTML 18.17763. DwtException is thrown after login.

[Root cause]
getComputedStyle couldn't get the value of style "position" in DwtCssStyle.getProperty on Edge44. Then DwtException was thrown in Dwt.setLocation.

[Fix]
Add process to get position from HtmlElement.style.position on Edge44.

[Note]
AjxEnv.browserVersion is
- 18.17763 on Edge44, EdgeHTML 18.17763
- 17.17134 on Edge42, EdgeHTML 17.17134
