### PR TITLE
ZCS-6715:JDK11 resource bundle loading change

### DIFF
--- a/src/com/zimbra/kabuki/servlets/Props2JsServlet.java
+++ b/src/com/zimbra/kabuki/servlets/Props2JsServlet.java
@@ -25,6 +25,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -49,6 +51,7 @@ import javax.servlet.http.HttpServletResponse;
 import com.zimbra.common.localconfig.LC;
 import com.zimbra.common.util.BufferStream;
 import com.zimbra.common.util.Props2Js;
+import com.zimbra.common.util.ZimbraLog;
 
 /**
  * This class looks for the resource bundle for the requested file (e.g.
@@ -410,6 +413,33 @@ public class Props2JsServlet extends HttpServlet {
                 }
             }
             return super.getResourceAsStream(rname);
+        }
+
+        @Override
+        public URL getResource(String rname) {
+            String filename = rname.replaceAll("^.*/", "");
+            Matcher matcher = RE_LOCALE.matcher(filename);
+            String locale = matcher.matches() ? matcher.group(1) : "";
+            String ext = rname.replaceAll("^[^\\.]*", "");
+            for (String basename : this.patterns) {
+                basename = basename.replaceAll("\\$\\{dir\\}", this.dir);
+                basename = basename.replaceAll("\\$\\{name\\}", this.name);
+                basename = replaceSystemProps(basename);
+                basename += locale + ext;
+                File file = new File(this.dirname+basename);
+                if (!file.exists()) {
+                    file = new File(basename);
+                }
+                if (file.exists()) {
+                    files.add(file);
+                    try {
+                        return file.toURI().toURL();
+                    } catch (MalformedURLException e) {
+                        ZimbraLog.webclient.debug("MalformedURLException:" + e);
+                    }
+                }
+            }
+            return super.getResource(rname);
         }
 
         private static String replaceSystemProps(String s) {

--- a/src/com/zimbra/kabuki/tools/i18n/CompareKeysTask.java
+++ b/src/com/zimbra/kabuki/tools/i18n/CompareKeysTask.java
@@ -18,6 +18,8 @@
 package com.zimbra.kabuki.tools.i18n;
 
 import java.io.*;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.*;
 import org.apache.tools.ant.*;
 import org.apache.tools.ant.types.*;
@@ -120,6 +122,15 @@ public class CompareKeysTask
 					return super.getResourceAsStream(path);
 				}
 			}
+			public URL getResource(String path) {
+                try {
+                    File file = new File(CompareKeysTask.this.dir, path);
+                    return file.toURI().toURL();
+                }
+                catch (MalformedURLException e) {
+                    return super.getResource(path);
+                }
+            }
 		};
 
 		// check keycodes for each locale


### PR DESCRIPTION
Issue: Resource bundles were not getting loaded with JDK11

Fix: Overriding getResource method of ClassLoader as the getBundle() now calls getResource() instead of getResourceAsStream()

Testing done:
Manual testing - Web client
No longer getting MissingResourceException

