### PR TITLE
ZBUG-866 : Fixing message content missing in chrome73

### DIFF
--- a/WebRoot/js/ajax/dwt/widgets/DwtIframe.js
+++ b/WebRoot/js/ajax/dwt/widgets/DwtIframe.js
@@ -261,7 +261,7 @@ DwtIframe.prototype._createFrame = function(html) {
 		if(self._onLoadHandler){
 			tmp[i++] = " onload='" + self._onLoadHandler + "'";
 		}
-		tmp[i++] = " ></iframe>";
+		tmp[i++] = " src='about:blank' ></iframe>";
 		self.setContent(tmp.join(''));
 
 		// Bug 7523: @import url() lines will make Gecko report

--- a/WebRoot/js/ajax/dwt/widgets/DwtIframe.js
+++ b/WebRoot/js/ajax/dwt/widgets/DwtIframe.js
@@ -261,7 +261,7 @@ DwtIframe.prototype._createFrame = function(html) {
 		if(self._onLoadHandler){
 			tmp[i++] = " onload='" + self._onLoadHandler + "'";
 		}
-		tmp[i++] = " src='javascript:\"\";' ></iframe>";
+		tmp[i++] = " ></iframe>";
 		self.setContent(tmp.join(''));
 
 		// Bug 7523: @import url() lines will make Gecko report


### PR DESCRIPTION
As described in ticket that src attribute of message-body-iframe
with "javascript:\" is preventing the content to be loaded at all.
Avoiding the practice to set any kind of url in src attribute to
iframe.