### PR TITLE
ZBUG-922 : ZWC Print Preview time reverts to GMT

### DIFF
--- a/WebRoot/js/ajax/util/AjxTimezone.js
+++ b/WebRoot/js/ajax/util/AjxTimezone.js
@@ -763,6 +763,10 @@ AjxTimezone._generateDefaultRule = function() {
 
 	// now that standard offset is determined, set serverId
 	rule.serverId = ["(GMT",AjxTimezone._generateShortName(rule.standard.offset, true),") ",AjxTimezone.AUTO_DETECTED].join("");
+	//To resolve brasilia timezone Issue this is hack.Details in ZBUG-922.
+	if (rule.serverId.includes('GMT-03.00')) {
+	  rule.serverId = "America/Sao_Paulo";
+	}
 
 	// bug 33800: guard against inverted daylight/standard onsets
 	if (rule.daylight && rule.daylight.offset < rule.standard.offset) {


### PR DESCRIPTION
ZWC Print Preview time reverts to GMT
Description : 
Steps to test:
    Set PC system tz to Brazil (GMT-3)
    Login or refresh ZWC session
    Select any email in inbox, note the date/time of the message.
    Invoke the Print action on the message.
    Observe the date/time in the print preview.
    Expected: date/time in preview should match what was displayed in ZWC.