### PR TITLE
ZBUG-2300, ZBUG-1844: added DOCTYPE to iframe

### DIFF
--- a/WebRoot/js/ajax/util/AjxStringUtil.js
+++ b/WebRoot/js/ajax/util/AjxStringUtil.js
@@ -2228,7 +2228,7 @@ function(html, okTags, untrustedAttrs) {
 	};
 	AjxStringUtil._traverseCleanHtml(htmlNode, ctxt);
 
-	var result = "<html>" + htmlNode.innerHTML + "</html>";
+	var result = "<!DOCTYPE html><html>" + htmlNode.innerHTML + "</html>";
 
 	var width = Math.max(htmlNode.scrollWidth, htmlNode.lastChild.scrollWidth);
 


### PR DESCRIPTION
**Problem:**
Text in an email is overlapping in message preview when line-height of span element is 0px. For example, `<span style="line-height: 0px;">`

**Steps to reproduce:**
1. go to Compose and choose HTML format
2. In body field, enter an email address, add a white space (the email address is changed to a link at this point), press Ctrl+Z , press End key, add some text and a line break
3. add some messages in multiple lines
4. send a message and show the received message

**Root cause:**
`<!DOCTYPE html>` is specified for entire Zimbra Web Client. However, an iframe which shows a message does not have any DOCTYPE. When `<!DOCTYPE html>` is not specified, a span with line-height 0px is collapsed.

**Change:**
Add `<!DOCTYPE html>` to iframe.

**Affected area:**
* message preview
* conversation preview
* appointment preview (like an invited appointment)
* task preview
* briefcase document preview