### PR TITLE
ZBUG-2558: In Out of office: In a month having 30 days, When select the End day as 31st of a next month it switch at the day 1st of the same month.

### DIFF
--- a/WebRoot/js/ajax/util/AjxDateUtil.js
+++ b/WebRoot/js/ajax/util/AjxDateUtil.js
@@ -1001,8 +1001,8 @@ function(value) {
 	date.setUTCSeconds(se);
 	date.setUTCMinutes(mi);
 	date.setUTCHours(hr);
-	date.setUTCDate(da);
 	date.setUTCMonth(mo - 1);
+	date.setUTCDate(da);
 	date.setUTCFullYear(yr);
 	yr = date.getFullYear();
 	mo = date.getMonth() + 1;


### PR DESCRIPTION
- Made changes in AjxDateUtil.js file to dateGMT2Local method to set the UTC Month for variable 'date' before setting UTC Day as for current month containing only 30 days, if the 31st day of any month was being selected, the 31st day was being carried over to the 1st of the month because it references the current month. Hence, month will now be specified before the day.