### PR TITLE
ZCS- 12659: WCAG | Classic UI | Medium Complexity | Headings

### DIFF
--- a/WebRoot/js/ajax/dwt/widgets/DwtBaseDialog.js
+++ b/WebRoot/js/ajax/dwt/widgets/DwtBaseDialog.js
@@ -498,7 +498,7 @@ DwtBaseDialog.prototype._createHtmlFromTemplate = function(templateId, data) {
 	if (this._titleEl) {
 		this.setAttribute('aria-labelledby', this._titleEl.id);
 		this._titleEl.setAttribute('role', 'heading');
-		this._titleEl.setAttribute('aria-level', '2');
+		this._titleEl.setAttribute('aria-level', '3');
 	}
 
     // NOTE: This is for backwards compatibility. There are just

--- a/WebRoot/js/ajax/dwt/widgets/DwtTreeItem.js
+++ b/WebRoot/js/ajax/dwt/widgets/DwtTreeItem.js
@@ -291,7 +291,15 @@ function(item) {
  */
 DwtTreeItem.prototype.getNestingLevel =
 function() {
-	return this.parent.getNestingLevel() + 1;
+	var nestingLevelCheck;
+	// the toplevel tree is zero, we can have only one level(1) heading in the page which is already defined in the banner,so initializing the toplevel with level2 for all nested folders
+	if (this.parent.getNestingLevel() == 0) {
+		nestingLevelCheck = this.parent.getNestingLevel() + 2;
+	}
+	else {
+		nestingLevelCheck = this.parent.getNestingLevel() + 1;
+	}
+	return (nestingLevelCheck > 6 ? 6 : nestingLevelCheck);
 };
 
 /**


### PR DESCRIPTION
**2.4.6_There are no heading throughout the Calendar Page.docx**
-The title of the add event dialog is level3

**2.4.6_heading issue-Mail.docx**
-The sidebar of all verticals has headings starting from level 2 and up to level 6 for nested folders.

See the changes of zm-web-client https://github.com/Zimbra/zm-web-client/pull/768