### PR TITLE
ZCS-12765: added notifyZimlets

### DIFF
--- a/WebRoot/js/ajax/dwt/widgets/DwtDialog.js
+++ b/WebRoot/js/ajax/dwt/widgets/DwtDialog.js
@@ -62,6 +62,8 @@ DwtDialog = function(params) {
 	params.className = params.className || "DwtDialog";
 	this._title = params.title = params.title || "";
 
+	window.appCtxt && appCtxt.notifyZimlets("onDwtDialog", [this, params]);
+
 	// standard buttons default to OK / Cancel
 	var standardButtons = params.standardButtons;
 	var extraButtons = params.extraButtons;
@@ -534,6 +536,13 @@ function(html, idx) {
 		}
 		html[idx++] = this._getButtonsContainerStartTemplate();
 		
+		var result = { handled: false, value: null };
+		window.appCtxt && appCtxt.notifyZimlets("onDwtDialog_addButtonsHtml", [this, html, idx, result]);
+		if (result.handled) {
+			html = result.value.html;
+			idx = result.value.idx;
+		}
+
 		if (leftButtons.length) {
 			html[idx++] = AjxMessageFormat.format(
 								  this._getButtonsAlignStartTemplate(),

--- a/WebRoot/js/ajax/util/AjxDateUtil.js
+++ b/WebRoot/js/ajax/util/AjxDateUtil.js
@@ -294,6 +294,12 @@ function(now, dateMSec, requireTime) {
 	if (dateMSec == null)
 		return "";
 
+	var result = { value: null };
+	appCtxt.notifyZimlets("onAjxDateUtil_computeDateStr", [now, dateMSec, requireTime, result]);
+	if (result.value) {
+		return result.value;
+	}
+
 	var date = new Date(dateMSec);
 	if (now.getTime() - dateMSec < AjxDateUtil.MSEC_PER_DAY &&
 		now.getDay() == date.getDay()) {

--- a/WebRoot/js/zimbra/common/ZmErrorDialog.js
+++ b/WebRoot/js/zimbra/common/ZmErrorDialog.js
@@ -49,11 +49,16 @@ ZmErrorDialog = function(parent, msgs) {
 
 	var reportButton = new DwtDialog_ButtonDescriptor(ZmErrorDialog.REPORT_BUTTON, msgs.report, DwtDialog.ALIGN_LEFT);
 	var detailButton = new DwtDialog_ButtonDescriptor(ZmErrorDialog.DETAIL_BUTTON, msgs.showDetails, DwtDialog.ALIGN_LEFT);
-	DwtMessageDialog.call(this, {parent:parent, extraButtons:[reportButton, detailButton], id:"ErrorDialog"});
 
-	this.registerCallback(ZmErrorDialog.REPORT_BUTTON, this._reportCallback, this);
-	this.registerCallback(ZmErrorDialog.DETAIL_BUTTON, this.showDetail, this);
-	
+	var result = { handled: false };
+	appCtxt.notifyZimlets("onZmErrorDialog", [this, parent, msgs, reportButton, detailButton, result]);
+
+	if (!result.handled) {
+		DwtMessageDialog.call(this, {parent:parent, extraButtons:[reportButton, detailButton], id:"ErrorDialog"});
+		this.registerCallback(ZmErrorDialog.REPORT_BUTTON, this._reportCallback, this);
+		this.registerCallback(ZmErrorDialog.DETAIL_BUTTON, this.showDetail, this);
+	}
+
 	this._showDetailsMsg = msgs.showDetails;
 	this._hideDetailsMsg = msgs.hideDetails;
 
@@ -132,7 +137,9 @@ function(msgStr, detailStr, style, title) {
 
 	// clear the 'detailsVisible' flag and reset the title of the 'showDetails' button
 	this._detailsVisible = false;
-	this._button[ZmErrorDialog.DETAIL_BUTTON].setText(this._showDetailsMsg);
+	if (this._button[ZmErrorDialog.DETAIL_BUTTON]) {
+		this._button[ZmErrorDialog.DETAIL_BUTTON].setText(this._showDetailsMsg);
+	}
 	
 	// Set the content, enveloped
 	this._updateContent();
@@ -332,5 +339,7 @@ ZmErrorDialog.prototype.showDetail =
 function() {
 	this._detailsVisible = !this._detailsVisible;
 	this._updateContent();
-	this._button[ZmErrorDialog.DETAIL_BUTTON].setText(this._detailsVisible ? this._hideDetailsMsg : this._showDetailsMsg);
+	if (this._button[ZmErrorDialog.DETAIL_BUTTON]) {
+		this._button[ZmErrorDialog.DETAIL_BUTTON].setText(this._detailsVisible ? this._hideDetailsMsg : this._showDetailsMsg);
+	}
 };


### PR DESCRIPTION
Add notifyZimlets to create custom zimlets.

Additional change:
* add `if` statements to check the existence of `this._button[ZmErrorDialog.DETAIL_BUTTON]` object. A zimlet can skip creating it.
