### PR TITLE
ZCS-12731 WCAG Re-opened Issues Part 2

### DIFF
--- a/WebRoot/js/ajax/dwt/widgets/DwtListView.js
+++ b/WebRoot/js/ajax/dwt/widgets/DwtListView.js
@@ -767,6 +767,7 @@ function() {
 		for (var i = 0; i < sz; i++) {
 	        Dwt.delClass(a[i], this._styleRe);
 			a[i].setAttribute('aria-selected', false);
+			this._updateAriaLabel(a[i]);
 	    }
 	    this._selectedItems.removeAll();
 		this._rightSelItem = this._selAnchor = null;
@@ -862,6 +863,12 @@ function(item, skipNotify, forceSelection) {
 	}
 };
 
+DwtListView.prototype._updateAriaLabel =
+function(element) {
+	var item = element.tagName ? this.getItemFromElement(element) : element;
+	this._updateLabelForItem(item);
+};
+
 DwtListView.prototype.setMultiSelection =
 function(clickedEl, bContained, ev) {
 	if (bContained) {
@@ -886,6 +893,7 @@ function(clickedEl, bContained, ev) {
 	this._setKbFocusElement(clickedEl);
 	this._selAnchor = clickedEl;
 	Dwt.addClass(this._kbAnchor, this._kbFocusClass);
+	this._updateAriaLabel(clickedEl);
 };
 
 DwtListView.prototype.setSelectedItems =
@@ -913,7 +921,6 @@ function(item, selected) {
 			el.focus();
 		}
 		this._selectedItems.add(el);
-		el.setAttribute('aria-selected', true);
 	}
 };
 
@@ -1299,6 +1306,7 @@ function(row, index) {
 
 	row.setAttribute('role', this.itemRole);
 	row.setAttribute('aria-selected', false);
+	this._updateAriaLabel(row);
 };
 
 // Placeholder function for any post-add processing
@@ -2214,7 +2222,6 @@ function(itemDiv, ev) {
 
 		// save new left click selection
 		this._selectedItems.add(itemDiv);
-		itemDiv.setAttribute('aria-selected', true);
 
 		this._setKbFocusElement(itemDiv);
 		this._selAnchor = itemDiv;
@@ -2301,10 +2308,12 @@ function(clickedEl, ev) {
 					this._selectedItems.add(el);
 					el.setAttribute('aria-selected', true);
 					Dwt.delClass(el, this._styleRe, selStyleClass);
+					this._updateAriaLabel(el);
 				}
 				else if (el.className.indexOf(selStyleClass) !== -1) {
 					Dwt.delClass(el, this._styleRe);		// , this._normalClass	MOW
 					el.setAttribute('aria-selected', false);
+					this._updateAriaLabel(el);
 				}
 			}
 

--- a/WebRoot/keys/AjxKeys.properties
+++ b/WebRoot/keys/AjxKeys.properties
@@ -272,12 +272,16 @@ list.DoubleClick.description = Double-click
 list.DoubleClick.sort = 30070
 
 list.Next.display = {ctrl}+ArrowDown
+list.Next.display.mac = {ctrl}+ArrowDown; {ctrl}+{shift}+ArrowDown
 list.Next.keycode = Ctrl+40
+list.Next.keycode.mac = Ctrl+40; Ctrl+Shift+40
 list.Next.description = Focus next item
 list.Next.sort = 30110
 
 list.Previous.display = {ctrl}+ArrowUp
+list.Previous.display.mac = {ctrl}+ArrowUp; {ctrl}+{shift}+ArrowUp
 list.Previous.keycode = Ctrl+38
+list.Previous.keycode.mac = Ctrl+38; Ctrl+Shift+38
 list.Previous.description = Focus previous item
 list.Previous.sort = 30120
 

--- a/WebRoot/keys/AjxKeys_ar.properties
+++ b/WebRoot/keys/AjxKeys_ar.properties
@@ -272,12 +272,16 @@ list.DoubleClick.description = \u0627\u0646\u0642\u0631 \u0627\u0644\u0639\u0646
 list.DoubleClick.sort = 30070
 
 list.Next.display = {ctrl}+\u0627\u0644\u0633\u0647\u0645 \u0644\u0623\u0633\u0641\u0644
+list.Next.display.mac = {ctrl}+\u0627\u0644\u0633\u0647\u0645 \u0644\u0623\u0633\u0641\u0644; {ctrl}+{shift}+\u0627\u0644\u0633\u0647\u0645 \u0644\u0623\u0633\u0641\u0644
 list.Next.keycode = Ctrl+40
+list.Next.keycode.mac = Ctrl+40; Ctrl+Shift+40
 list.Next.description = \u0627\u0644\u062a\u0631\u0643\u064a\u0632 \u0639\u0644\u0649 \u0627\u0644\u0639\u0646\u0635\u0631 \u0627\u0644\u062a\u0627\u0644\u064a \u0628\u062f\u0648\u0646 \u062a\u062d\u062f\u064a\u062f
 list.Next.sort = 30110
 
 list.Previous.display = {ctrl}+\u0627\u0644\u0633\u0647\u0645 \u0644\u0623\u0639\u0644\u0649
+list.Previous.display.mac = {ctrl}+\u0627\u0644\u0633\u0647\u0645 \u0644\u0623\u0639\u0644\u0649; {ctrl}+{shift}+\u0627\u0644\u0633\u0647\u0645 \u0644\u0623\u0639\u0644\u0649
 list.Previous.keycode = Ctrl+38
+list.Previous.keycode.mac = Ctrl+38; Ctrl+Shift+38
 list.Previous.description = \u0627\u0644\u062a\u0631\u0643\u064a\u0632 \u0639\u0644\u0649 \u0627\u0644\u0639\u0646\u0635\u0631 \u0627\u0644\u0633\u0627\u0628\u0642 \u0628\u062f\u0648\u0646 \u062a\u062d\u062f\u064a\u062f
 list.Previous.sort = 30120
 

--- a/WebRoot/keys/AjxKeys_ca.properties
+++ b/WebRoot/keys/AjxKeys_ca.properties
@@ -272,12 +272,16 @@ list.DoubleClick.description = Doble clic
 list.DoubleClick.sort = 30070
 
 list.Next.display = {ctrl}+Fletxa avall
+list.Next.display.mac = {ctrl}+Fletxa avall; {ctrl}+{shift}+Fletxa avall
 list.Next.keycode = Ctrl+40
+list.Next.keycode.mac = Ctrl+40; Ctrl+Shift+40
 list.Next.description = Centra a l\u2019element seg\u00fcent
 list.Next.sort = 30110
 
 list.Previous.display = {ctrl}+Fletxa amunt
+list.Previous.display.mac = {ctrl}+Fletxa amunt; {ctrl}+{shift}+Fletxa amunt
 list.Previous.keycode = Ctrl+38
+list.Previous.keycode.mac = Ctrl+38; Ctrl+Shift+38
 list.Previous.description = Centra a l\u2019element anterior
 list.Previous.sort = 30120
 

--- a/WebRoot/keys/AjxKeys_da.properties
+++ b/WebRoot/keys/AjxKeys_da.properties
@@ -272,12 +272,16 @@ list.DoubleClick.description = Dobbeltklik
 list.DoubleClick.sort = 30070
 
 list.Next.display = {ctrl}+PilNed
+list.Next.display.mac = {ctrl}+PilNed; {ctrl}+{shift}+PilNed
 list.Next.keycode = Ctrl+40
+list.Next.keycode.mac = Ctrl+40; Ctrl+Shift+40
 list.Next.description = Fokuser p\u00e5 n\u00e6ste element
 list.Next.sort = 30110
 
 list.Previous.display = {ctrl}+PilOp
+list.Previous.display.mac = {ctrl}+PilOp; {ctrl}+{shift}+PilOp
 list.Previous.keycode = Ctrl+38
+list.Previous.keycode.mac = Ctrl+38; Ctrl+Shift+38
 list.Previous.description = Fokuser p\u00e5 forrige element
 list.Previous.sort = 30120
 

--- a/WebRoot/keys/AjxKeys_de.properties
+++ b/WebRoot/keys/AjxKeys_de.properties
@@ -272,12 +272,16 @@ list.DoubleClick.description = Doppelklicken
 list.DoubleClick.sort = 30070
 
 list.Next.display = {ctrl}+PfeilAbw\u00e4rts
+list.Next.display.mac = {ctrl}+ArrowDown; {ctrl}+{shift}+PfeilAbw\u00e4rts
 list.Next.keycode = Ctrl+40
+list.Next.keycode.mac = Ctrl+40; Ctrl+Shift+40
 list.Next.description = Fokus auf n\u00e4chstes Objekt
 list.Next.sort = 30110
 
 list.Previous.display = {ctrl}+PfeilAufw\u00e4rts
+list.Previous.display.mac = {ctrl}+ArrowUp; {ctrl}+{shift}+PfeilAufw\u00e4rts
 list.Previous.keycode = Ctrl+38
+list.Previous.keycode.mac = Ctrl+38; Ctrl+Shift+38
 list.Previous.description = Fokus auf vorheriges Objekt
 list.Previous.sort = 30120
 

--- a/WebRoot/keys/AjxKeys_en_AU.properties
+++ b/WebRoot/keys/AjxKeys_en_AU.properties
@@ -272,12 +272,16 @@ list.DoubleClick.description = Double-click
 list.DoubleClick.sort = 30070
 
 list.Next.display = {ctrl}+ArrowDown
+list.Next.display.mac = {ctrl}+ArrowDown; {ctrl}+{shift}+ArrowDown
 list.Next.keycode = Ctrl+40
+list.Next.keycode.mac = Ctrl+40; Ctrl+Shift+40
 list.Next.description = Focus next item
 list.Next.sort = 30110
 
 list.Previous.display = {ctrl}+ArrowUp
+list.Previous.display.mac = {ctrl}+ArrowUp; {ctrl}+{shift}+ArrowUp
 list.Previous.keycode = Ctrl+38
+list.Previous.keycode.mac = Ctrl+38; Ctrl+Shift+38
 list.Previous.description = Focus previous item
 list.Previous.sort = 30120
 

--- a/WebRoot/keys/AjxKeys_en_GB.properties
+++ b/WebRoot/keys/AjxKeys_en_GB.properties
@@ -272,12 +272,16 @@ list.DoubleClick.description = Double-click
 list.DoubleClick.sort = 30070
 
 list.Next.display = {ctrl}+ArrowDown
+list.Next.display.mac = {ctrl}+ArrowDown; {ctrl}+{shift}+ArrowDown
 list.Next.keycode = Ctrl+40
+list.Next.keycode.mac = Ctrl+40; Ctrl+Shift+40
 list.Next.description = Focus next item
 list.Next.sort = 30110
 
 list.Previous.display = {ctrl}+ArrowUp
+list.Previous.display.mac = {ctrl}+ArrowUp; {ctrl}+{shift}+ArrowUp
 list.Previous.keycode = Ctrl+38
+list.Previous.keycode.mac = Ctrl+38; Ctrl+Shift+38
 list.Previous.description = Focus previous item
 list.Previous.sort = 30120
 

--- a/WebRoot/keys/AjxKeys_es.properties
+++ b/WebRoot/keys/AjxKeys_es.properties
@@ -272,12 +272,16 @@ list.DoubleClick.description = Hacer doble clic
 list.DoubleClick.sort = 30070
 
 list.Next.display = {ctrl}+Flecha hacia abajo
+list.Next.display.mac = {ctrl}+Flecha hacia abajo; {ctrl}+{shift}+Flecha hacia abajo
 list.Next.keycode = Ctrl+40
+list.Next.keycode.mac = Ctrl+40; Ctrl+Shift+40
 list.Next.description = Enfocar en siguiente elemento
 list.Next.sort = 30110
 
 list.Previous.display = {ctrl}+Flecha hacia arriba
+list.Previous.display.mac = {ctrl}+Flecha hacia arriba; {ctrl}+{shift}+Flecha hacia arriba
 list.Previous.keycode = Ctrl+38
+list.Previous.keycode.mac = Ctrl+38; Ctrl+Shift+38
 list.Previous.description = Enfocar en elemento anterior
 list.Previous.sort = 30120
 

--- a/WebRoot/keys/AjxKeys_eu.properties
+++ b/WebRoot/keys/AjxKeys_eu.properties
@@ -272,12 +272,16 @@ list.DoubleClick.description = Egin klik bikoitza
 list.DoubleClick.sort = 30070
 
 list.Next.display = {ctrl}+Behera gezia
+list.Next.display.mac = {ctrl}+Behera gezia; {ctrl}+{shift}+Behera gezia
 list.Next.keycode = Ctrl+40
+list.Next.keycode.mac = Ctrl+40; Ctrl+Shift+40
 list.Next.description = Fokuratu hurrengo elementuan
 list.Next.sort = 30110
 
 list.Previous.display = {ctrl}+Gora gezia
+list.Previous.display.mac = {ctrl}+Gora gezia; {ctrl}+{shift}+Gora gezia
 list.Previous.keycode = Ctrl+38
+list.Previous.keycode.mac = Ctrl+38; Ctrl+Shift+38
 list.Previous.description = Fokuratu aurreko elementuan
 list.Previous.sort = 30120
 

--- a/WebRoot/keys/AjxKeys_fr.properties
+++ b/WebRoot/keys/AjxKeys_fr.properties
@@ -272,12 +272,16 @@ list.DoubleClick.description = Double-cliquer
 list.DoubleClick.sort = 30070
 
 list.Next.display = {ctrl}+Fl\u00e8che Bas
+list.Next.display.mac = {ctrl}+Fl\u00e8che Bas; {ctrl}+{shift}+Fl\u00e8che Bas
 list.Next.keycode = Ctrl+40
+list.Next.keycode.mac = Ctrl+40; Ctrl+Shift+40
 list.Next.description = Activer l\u2019objet suivant
 list.Next.sort = 30110
 
 list.Previous.display = {ctrl}+Fl\u00e8che Haut
+list.Previous.display.mac = {ctrl}+Fl\u00e8che Haut; {ctrl}+{shift}+Fl\u00e8che Haut
 list.Previous.keycode = Ctrl+38
+list.Previous.keycode.mac = Ctrl+38; Ctrl+Shift+38
 list.Previous.description = Activer l\u2019objet pr\u00e9c\u00e9dent
 list.Previous.sort = 30120
 

--- a/WebRoot/keys/AjxKeys_fr_CA.properties
+++ b/WebRoot/keys/AjxKeys_fr_CA.properties
@@ -272,12 +272,16 @@ list.DoubleClick.description = Double-cliquer
 list.DoubleClick.sort = 30070
 
 list.Next.display = {ctrl}+Fl\u00e8che Bas
+list.Next.display.mac = {ctrl}+Fl\u00e8che Bas; {ctrl}+{shift}+Fl\u00e8che Bas
 list.Next.keycode = Ctrl+40
+list.Next.keycode.mac = Ctrl+40; Ctrl+Shift+40
 list.Next.description = Activer l\u2019objet suivant
 list.Next.sort = 30110
 
 list.Previous.display = {ctrl}+Fl\u00e8che Haut
+list.Previous.display.mac = {ctrl}+Fl\u00e8che Haut; {ctrl}+{shift}+Fl\u00e8che Haut
 list.Previous.keycode = Ctrl+38
+list.Previous.keycode.mac = Ctrl+38; Ctrl+Shift+38
 list.Previous.description = Activer l\u2019objet pr\u00e9c\u00e9dent
 list.Previous.sort = 30120
 

--- a/WebRoot/keys/AjxKeys_hi.properties
+++ b/WebRoot/keys/AjxKeys_hi.properties
@@ -272,12 +272,16 @@ list.DoubleClick.description = \u091a\u092f\u0928\u093f\u0924 \u0906\u0907\u091f
 list.DoubleClick.sort = 30070
 
 list.Next.display = {ctrl}+ArrowDown
+list.Next.display.mac = {ctrl}+ArrowDown; {ctrl}+{shift}+ArrowDown
 list.Next.keycode = Ctrl+40
+list.Next.keycode.mac = Ctrl+40; Ctrl+Shift+40
 list.Next.description = \u091a\u092f\u0928 \u0915\u093f\u090f \u092c\u093f\u0928\u093e \u0905\u0917\u0932\u0947 \u0906\u0907\u091f\u092e \u092a\u0930 \u092b\u093c\u094b\u0915\u0938 \u0915\u0930\u0947\u0902
 list.Next.sort = 30110
 
 list.Previous.display = {ctrl}+ArrowUp
+list.Previous.display.mac = {ctrl}+ArrowUp; {ctrl}+{shift}+ArrowUp
 list.Previous.keycode = Ctrl+38
+list.Previous.keycode.mac = Ctrl+38; Ctrl+Shift+38
 list.Previous.description = \u091a\u092f\u0928 \u0915\u093f\u090f \u092c\u093f\u0928\u093e \u092a\u093f\u091b\u0932\u0947 \u0906\u0907\u091f\u092e \u092a\u0930 \u092b\u093c\u094b\u0915\u0938 \u0915\u0930\u0947\u0902
 list.Previous.sort = 30120
 

--- a/WebRoot/keys/AjxKeys_hr.properties
+++ b/WebRoot/keys/AjxKeys_hr.properties
@@ -272,12 +272,16 @@ list.DoubleClick.description = Double-click
 list.DoubleClick.sort = 30070
 
 list.Next.display = {ctrl}+ArrowDown
+list.Next.display.mac = {ctrl}+ArrowDown; {ctrl}+{shift}+ArrowDown
 list.Next.keycode = Ctrl+40
+list.Next.keycode.mac = Ctrl+40; Ctrl+Shift+40
 list.Next.description = Focus next item
 list.Next.sort = 30110
 
 list.Previous.display = {ctrl}+ArrowUp
+list.Previous.display.mac = {ctrl}+ArrowUp; {ctrl}+{shift}+ArrowUp
 list.Previous.keycode = Ctrl+38
+list.Previous.keycode.mac = Ctrl+38; Ctrl+Shift+38
 list.Previous.description = Focus previous item
 list.Previous.sort = 30120
 

--- a/WebRoot/keys/AjxKeys_hu.properties
+++ b/WebRoot/keys/AjxKeys_hu.properties
@@ -272,12 +272,16 @@ list.DoubleClick.description = Dupla kattint\u00e1s
 list.DoubleClick.sort = 30070
 
 list.Next.display = {ctrl}+ArrowDown
+list.Next.display.mac = {ctrl}+ArrowDown; {ctrl}+{shift}+ArrowDown
 list.Next.keycode = Ctrl+40
+list.Next.keycode.mac = Ctrl+40; Ctrl+Shift+40
 list.Next.description = F\u00f3kusz a k\u00f6vetkez\u0151 elemre
 list.Next.sort = 30110
 
 list.Previous.display = {ctrl}+ArrowUp
+list.Previous.display.mac = {ctrl}+ArrowUp; {ctrl}+{shift}+ArrowUp
 list.Previous.keycode = Ctrl+38
+list.Previous.keycode.mac = Ctrl+38; Ctrl+Shift+38
 list.Previous.description = F\u00f3kusz az el\u0151z\u0151 elemre
 list.Previous.sort = 30120
 

--- a/WebRoot/keys/AjxKeys_in.properties
+++ b/WebRoot/keys/AjxKeys_in.properties
@@ -272,12 +272,16 @@ list.DoubleClick.description = Klik dua kali
 list.DoubleClick.sort = 30070
 
 list.Next.display = {ctrl}+Panah Turun
+list.Next.display.mac = {ctrl}+Panah Turun; {ctrl}+{shift}+Panah Turun
 list.Next.keycode = Ctrl+40
+list.Next.keycode.mac = Ctrl+40; Ctrl+Shift+40
 list.Next.description = Fokus item berikutnya
 list.Next.sort = 30110
 
 list.Previous.display = {ctrl}+Panah Naik
+list.Previous.display.mac = {ctrl}+Panah Naik; {ctrl}+{shift}+Panah Naik
 list.Previous.keycode = Ctrl+38
+list.Previous.keycode.mac = Ctrl+38; Ctrl+Shift+38
 list.Previous.description = Fokus item sebelumnya
 list.Previous.sort = 30120
 

--- a/WebRoot/keys/AjxKeys_it.properties
+++ b/WebRoot/keys/AjxKeys_it.properties
@@ -272,12 +272,16 @@ list.DoubleClick.description = Doppio clic
 list.DoubleClick.sort = 30070
 
 list.Next.display = {ctrl}+FrecciaGi\u00f9
+list.Next.display.mac = {ctrl}+FrecciaGi\u00f9; {ctrl}+{shift}+FrecciaGi\u00f9
 list.Next.keycode = Ctrl+40
+list.Next.keycode.mac = Ctrl+40; Ctrl+Shift+40
 list.Next.description = Evidenzia elemento successivo
 list.Next.sort = 30110
 
 list.Previous.display = {ctrl}+FrecciaSu
+list.Previous.display.mac = {ctrl}+FrecciaSu; {ctrl}+{shift}+FrecciaSu
 list.Previous.keycode = Ctrl+38
+list.Previous.keycode.mac = Ctrl+38; Ctrl+Shift+38
 list.Previous.description = Evidenzia elemento precedente
 list.Previous.sort = 30120
 

--- a/WebRoot/keys/AjxKeys_iw.properties
+++ b/WebRoot/keys/AjxKeys_iw.properties
@@ -272,12 +272,16 @@ list.DoubleClick.description = \u05dc\u05d7\u05d9\u05e6\u05d4 \u05db\u05e4\u05d5
 list.DoubleClick.sort = 30070
 
 list.Next.display = {ctrl}+\u05d7\u05e5 \u05dc\u05de\u05d8\u05d4
+list.Next.display.mac = {ctrl}+\u05d7\u05e5 \u05dc\u05de\u05d8\u05d4; {ctrl}+{shift}+\u05d7\u05e5 \u05dc\u05de\u05d8\u05d4
 list.Next.keycode = Ctrl+40
+list.Next.keycode.mac = Ctrl+40; Ctrl+Shift+40
 list.Next.description = \u05d4\u05ea\u05de\u05e7\u05d3 \u05d1\u05e4\u05e8\u05d9\u05d8 \u05d4\u05d1\u05d0
 list.Next.sort = 30110
 
 list.Previous.display = {ctrl}+\u05d7\u05e5 \u05dc\u05de\u05e2\u05dc\u05d4
+list.Previous.display.mac = {ctrl}+\u05d7\u05e5 \u05dc\u05de\u05e2\u05dc\u05d4; {ctrl}+{shift}+\u05d7\u05e5 \u05dc\u05de\u05e2\u05dc\u05d4
 list.Previous.keycode = Ctrl+38
+list.Previous.keycode.mac = Ctrl+38; Ctrl+Shift+38
 list.Previous.description = \u05d4\u05ea\u05de\u05e7\u05d3 \u05d1\u05e4\u05e8\u05d9\u05d8 \u05d4\u05e7\u05d5\u05d3\u05dd
 list.Previous.sort = 30120
 

--- a/WebRoot/keys/AjxKeys_ja.properties
+++ b/WebRoot/keys/AjxKeys_ja.properties
@@ -273,12 +273,16 @@ list.DoubleClick.description = \u30c0\u30d6\u30eb\u30af\u30ea\u30c3\u30af
 list.DoubleClick.sort = 30070
 
 list.Next.display = {ctrl}+ArrowDown
+list.Next.display.mac = {ctrl}+ArrowDown; {ctrl}+{shift}+ArrowDown
 list.Next.keycode = Ctrl+40
+list.Next.keycode.mac = Ctrl+40; Ctrl+Shift+40
 list.Next.description = \u6b21\u306e\u9805\u76ee\u306b\u30d5\u30a9\u30fc\u30ab\u30b9
 list.Next.sort = 30110
 
 list.Previous.display = {ctrl}+ArrowUp
+list.Previous.display.mac = {ctrl}+ArrowUp; {ctrl}+{shift}+ArrowUp
 list.Previous.keycode = Ctrl+38
+list.Previous.keycode.mac = Ctrl+38; Ctrl+Shift+38
 list.Previous.description = \u524d\u306e\u9805\u76ee\u306b\u30d5\u30a9\u30fc\u30ab\u30b9
 list.Previous.sort = 30120
 

--- a/WebRoot/keys/AjxKeys_ko.properties
+++ b/WebRoot/keys/AjxKeys_ko.properties
@@ -272,12 +272,16 @@ list.DoubleClick.description = \ub450 \ubc88 \ud074\ub9ad
 list.DoubleClick.sort = 30070
 
 list.Next.display = {ctrl}+\uc544\ub798 \ud654\uc0b4\ud45c
+list.Next.display.mac = {ctrl}+\uc544\ub798 \ud654\uc0b4\ud45c; {ctrl}+{shift}+\uc544\ub798 \ud654\uc0b4\ud45c
 list.Next.keycode = Ctrl+40
+list.Next.keycode.mac = Ctrl+40; Ctrl+Shift+40
 list.Next.description = \ub2e4\uc74c \ud56d\ubaa9 \ud3ec\ucee4\uc2a4
 list.Next.sort = 30110
 
 list.Previous.display = {ctrl}+\uc704 \ud654\uc0b4\ud45c
+list.Previous.display.mac = {ctrl}+\uc704 \ud654\uc0b4\ud45c; {ctrl}+{shift}+\uc704 \ud654\uc0b4\ud45c
 list.Previous.keycode = Ctrl+38
+list.Previous.keycode.mac = Ctrl+38; Ctrl+Shift+38
 list.Previous.description = \uc774\uc804 \ud56d\ubaa9 \ud3ec\ucee4\uc2a4
 list.Previous.sort = 30120
 

--- a/WebRoot/keys/AjxKeys_lo.properties
+++ b/WebRoot/keys/AjxKeys_lo.properties
@@ -272,12 +272,16 @@ list.DoubleClick.description = \u0e84\u0ea5\u0eb4\u0e81\u0eaa\u0ead\u0e87\u0ec0\
 list.DoubleClick.sort = 30070
 
 list.Next.display = {ctrl}+ArrowDown
+list.Next.display.mac = {ctrl}+ArrowDown; {ctrl}+{shift}+ArrowDown
 list.Next.keycode = Ctrl+40
+list.Next.keycode.mac = Ctrl+40; Ctrl+Shift+40
 list.Next.description = \u0eaa\u0eb8\u0ea1\u0ec3\u0eaa\u0ec8\u0ea5\u0eb2\u0e8d\u0e81\u0eb2\u0e99\u0e95\u0ecd\u0ec8\u0ec4\u0e9b
 list.Next.sort = 30110
 
 list.Previous.display = {ctrl}+ArrowUp
+list.Previous.display.mac = {ctrl}+ArrowUp; {ctrl}+{shift}+ArrowUp
 list.Previous.keycode = Ctrl+38
+list.Previous.keycode.mac = Ctrl+38; Ctrl+Shift+38
 list.Previous.description = \u0eaa\u0eb8\u0ea1\u0ec3\u0eaa\u0ec8\u0ea5\u0eb2\u0e8d\u0e81\u0eb2\u0e99\u0e97\u0eb5\u0ec8\u0e9c\u0ec8\u0eb2\u0e99\u0ea1\u0eb2
 list.Previous.sort = 30120
 

--- a/WebRoot/keys/AjxKeys_ms.properties
+++ b/WebRoot/keys/AjxKeys_ms.properties
@@ -272,12 +272,16 @@ list.DoubleClick.description = Klik dua kali
 list.DoubleClick.sort = 30070
 
 list.Next.display = {ctrl}+AnakPanahBawah
+list.Next.display.mac = {ctrl}+AnakPanahBawah; {ctrl}+{shift}+AnakPanahBawah
 list.Next.keycode = Ctrl+40
+list.Next.keycode.mac = Ctrl+40; Ctrl+Shift+40
 list.Next.description = Fokus pada item seterusnya
 list.Next.sort = 30110
 
 list.Previous.display = {ctrl}+AnakPanahAtas
+list.Previous.display.mac = {ctrl}+AnakPanahAtas; {ctrl}+{shift}+AnakPanahAtas
 list.Previous.keycode = Ctrl+38
+list.Previous.keycode.mac = Ctrl+38; Ctrl+Shift+38
 list.Previous.description = Fokus pada item sebelumnya
 list.Previous.sort = 30120
 

--- a/WebRoot/keys/AjxKeys_nl.properties
+++ b/WebRoot/keys/AjxKeys_nl.properties
@@ -272,12 +272,16 @@ list.DoubleClick.description = Op het geselecteerde item dubbelklikken
 list.DoubleClick.sort = 30070
 
 list.Next.display = {ctrl}+ArrowDown
+list.Next.display.mac = {ctrl}+ArrowDown; {ctrl}+{shift}+ArrowDown
 list.Next.keycode = Ctrl+40
+list.Next.keycode.mac = Ctrl+40; Ctrl+Shift+40
 list.Next.description = Het volgende item markeren zonder het te selecteren
 list.Next.sort = 30110
 
 list.Previous.display = {ctrl}+ArrowUp
+list.Previous.display.mac = {ctrl}+ArrowUp; {ctrl}+{shift}+ArrowUp
 list.Previous.keycode = Ctrl+38
+list.Previous.keycode.mac = Ctrl+38; Ctrl+Shift+38
 list.Previous.description = Het vorige item markeren zonder het te selecteren
 list.Previous.sort = 30120
 

--- a/WebRoot/keys/AjxKeys_no.properties
+++ b/WebRoot/keys/AjxKeys_no.properties
@@ -272,12 +272,16 @@ list.DoubleClick.description = Dobbeltklikk
 list.DoubleClick.sort = 30070
 
 list.Next.display = {ctrl}+ArrowDown
+list.Next.display.mac = {ctrl}+ArrowDown; {ctrl}+{shift}+ArrowDown
 list.Next.keycode = Ctrl+40
+list.Next.keycode.mac = Ctrl+40; Ctrl+Shift+40
 list.Next.description = Fokuser p\u00e5 neste element
 list.Next.sort = 30110
 
 list.Previous.display = {ctrl}+ArrowUp
+list.Previous.display.mac = {ctrl}+ArrowUp; {ctrl}+{shift}+ArrowUp
 list.Previous.keycode = Ctrl+38
+list.Previous.keycode.mac = Ctrl+38; Ctrl+Shift+38
 list.Previous.description = Fokuser p\u00e5 forrige element
 list.Previous.sort = 30120
 

--- a/WebRoot/keys/AjxKeys_pl.properties
+++ b/WebRoot/keys/AjxKeys_pl.properties
@@ -272,12 +272,16 @@ list.DoubleClick.description = Kliknij dwukrotnie
 list.DoubleClick.sort = 30070
 
 list.Next.display = {ctrl}+Strza\u0142ka w d\u00f3\u0142
+list.Next.display.mac = {ctrl}+Strza\u0142ka w d\u00f3\u0142; {ctrl}+{shift}+Strza\u0142ka w d\u00f3\u0142
 list.Next.keycode = Ctrl+40
+list.Next.keycode.mac = Ctrl+40; Ctrl+Shift+40
 list.Next.description = Prze\u0142\u0105cz na nast\u0119pny element
 list.Next.sort = 30110
 
 list.Previous.display = {ctrl}+Strza\u0142ka w g\u00f3r\u0119
+list.Previous.display.mac = {ctrl}+Strza\u0142ka w g\u00f3r\u0119; {ctrl}+{shift}+Strza\u0142ka w g\u00f3r\u0119
 list.Previous.keycode = Ctrl+38
+list.Previous.keycode.mac = Ctrl+38; Ctrl+Shift+38
 list.Previous.description = Prze\u0142\u0105cz na poprzedni element
 list.Previous.sort = 30120
 

--- a/WebRoot/keys/AjxKeys_pt.properties
+++ b/WebRoot/keys/AjxKeys_pt.properties
@@ -272,12 +272,16 @@ list.DoubleClick.description = Clicar duas vezes
 list.DoubleClick.sort = 30070
 
 list.Next.display = {ctrl}+Seta para baixo
+list.Next.display.mac = {ctrl}+Seta para baixo; {ctrl}+{shift}+Seta para baixo
 list.Next.keycode = Ctrl+40
+list.Next.keycode.mac = Ctrl+40; Ctrl+Shift+40
 list.Next.description = Real\u00e7ar pr\u00f3ximo item
 list.Next.sort = 30110
 
 list.Previous.display = {ctrl}+Seta para cima
+list.Previous.display.mac = {ctrl}+Seta para cima; {ctrl}+{shift}+Seta para cima
 list.Previous.keycode = Ctrl+38
+list.Previous.keycode.mac = Ctrl+38; Ctrl+Shift+38
 list.Previous.description = Real\u00e7ar item anterior
 list.Previous.sort = 30120
 

--- a/WebRoot/keys/AjxKeys_pt_BR.properties
+++ b/WebRoot/keys/AjxKeys_pt_BR.properties
@@ -272,12 +272,16 @@ list.DoubleClick.description = Clicar duas vezes
 list.DoubleClick.sort = 30070
 
 list.Next.display = {ctrl}+Seta para baixo
+list.Next.display.mac = {ctrl}+Seta para baixo; {ctrl}+{shift}+Seta para baixo
 list.Next.keycode = Ctrl+40
+list.Next.keycode.mac = Ctrl+40; Ctrl+Shift+40
 list.Next.description = Foco no pr\u00f3ximo item
 list.Next.sort = 30110
 
 list.Previous.display = {ctrl}+Seta para cima
+list.Previous.display.mac = {ctrl}+Seta para cima; {ctrl}+{shift}+Seta para cima
 list.Previous.keycode = Ctrl+38
+list.Previous.keycode.mac = Ctrl+38; Ctrl+Shift+38
 list.Previous.description = Foco no item anterior
 list.Previous.sort = 30120
 

--- a/WebRoot/keys/AjxKeys_ro.properties
+++ b/WebRoot/keys/AjxKeys_ro.properties
@@ -272,12 +272,16 @@ list.DoubleClick.description = Dublu clic
 list.DoubleClick.sort = 30070
 
 list.Next.display = {ctrl}+s\u0103geat\u0103 jos
+list.Next.display.mac = {ctrl}+s\u0103geat\u0103 jos; {ctrl}+{shift}+s\u0103geat\u0103 jos
 list.Next.keycode = Ctrl+40
+list.Next.keycode.mac = Ctrl+40; Ctrl+Shift+40
 list.Next.description = Focalizare urm\u0103torul element
 list.Next.sort = 30110
 
 list.Previous.display = {ctrl}+s\u0103geat\u0103 sus
+list.Previous.display.mac = {ctrl}+s\u0103geat\u0103 sus; {ctrl}+{shift}+s\u0103geat\u0103 sus
 list.Previous.keycode = Ctrl+38
+list.Previous.keycode.mac = Ctrl+38; Ctrl+Shift+38
 list.Previous.description = Focalizare elementul precedent
 list.Previous.sort = 30120
 

--- a/WebRoot/keys/AjxKeys_ru.properties
+++ b/WebRoot/keys/AjxKeys_ru.properties
@@ -272,12 +272,16 @@ list.DoubleClick.description = \u0414\u0432\u0430\u0436\u0434\u044b \u0449\u0435
 list.DoubleClick.sort = 30070
 
 list.Next.display = {ctrl}+\u0421\u0442\u0440\u0435\u043b\u043a\u0430 \u0432\u043d\u0438\u0437
+list.Next.display.mac = {ctrl}+\u0421\u0442\u0440\u0435\u043b\u043a\u0430 \u0432\u043d\u0438\u0437; {ctrl}+{shift}+\u0421\u0442\u0440\u0435\u043b\u043a\u0430 \u0432\u043d\u0438\u0437
 list.Next.keycode = Ctrl+40
+list.Next.keycode.mac = Ctrl+40; Ctrl+Shift+40
 list.Next.description = \u0424\u043e\u043a\u0443\u0441 \u043d\u0430 \u0441\u043b\u0435\u0434\u0443\u044e\u0449\u0435\u043c \u044d\u043b\u0435\u043c\u0435\u043d\u0442\u0435
 list.Next.sort = 30110
 
 list.Previous.display = {ctrl}+\u0421\u0442\u0440\u0435\u043b\u043a\u0430 \u0432\u0432\u0435\u0440\u0445
+list.Previous.display.mac = {ctrl}+\u0421\u0442\u0440\u0435\u043b\u043a\u0430 \u0432\u0432\u0435\u0440\u0445; {ctrl}+{shift}+\u0421\u0442\u0440\u0435\u043b\u043a\u0430 \u0432\u0432\u0435\u0440\u0445
 list.Previous.keycode = Ctrl+38
+list.Previous.keycode.mac = Ctrl+38; Ctrl+Shift+38
 list.Previous.description = \u0424\u043e\u043a\u0443\u0441 \u043d\u0430 \u043f\u0440\u0435\u0434\u044b\u0434\u0443\u0449\u0435\u043c \u044d\u043b\u0435\u043c\u0435\u043d\u0442\u0435
 list.Previous.sort = 30120
 

--- a/WebRoot/keys/AjxKeys_sl.properties
+++ b/WebRoot/keys/AjxKeys_sl.properties
@@ -272,12 +272,16 @@ list.DoubleClick.description = Dvokliknite
 list.DoubleClick.sort = 30070
 
 list.Next.display = {ctrl}+pu\u0161\u010dica navzdol
+list.Next.display.mac = {ctrl}+pu\u0161\u010dica navzdol; {ctrl}+{shift}+pu\u0161\u010dica navzdol
 list.Next.keycode = Ctrl+40
+list.Next.keycode.mac = Ctrl+40; Ctrl+Shift+40
 list.Next.description = Izostri naslednji element
 list.Next.sort = 30110
 
 list.Previous.display = {ctrl}+pu\u0161\u010dica navzgor
+list.Previous.display.mac = {ctrl}+pu\u0161\u010dica navzgor; {ctrl}+{shift}+pu\u0161\u010dica navzgor
 list.Previous.keycode = Ctrl+38
+list.Previous.keycode.mac = Ctrl+38; Ctrl+Shift+38
 list.Previous.description = Izostri prej\u0161nji element
 list.Previous.sort = 30120
 

--- a/WebRoot/keys/AjxKeys_sv.properties
+++ b/WebRoot/keys/AjxKeys_sv.properties
@@ -272,12 +272,16 @@ list.DoubleClick.description = Dubbelklicka
 list.DoubleClick.sort = 30070
 
 list.Next.display = {ctrl}+Ned\u00e5tpil
+list.Next.display.mac = {ctrl}+Ned\u00e5tpil; {ctrl}+{shift}+Ned\u00e5tpil
 list.Next.keycode = Ctrl+40
+list.Next.keycode.mac = Ctrl+40; Ctrl+Shift+40
 list.Next.description = Fokusera p\u00e5 n\u00e4sta objekt
 list.Next.sort = 30110
 
 list.Previous.display = {ctrl}+Upp\u00e5tpil
+list.Previous.display.mac = {ctrl}+Upp\u00e5tpil; {ctrl}+{shift}+Upp\u00e5tpil
 list.Previous.keycode = Ctrl+38
+list.Previous.keycode.mac = Ctrl+38; Ctrl+Shift+38
 list.Previous.description = Fokusera p\u00e5 f\u00f6reg\u00e5ende objekt
 list.Previous.sort = 30120
 

--- a/WebRoot/keys/AjxKeys_ta.properties
+++ b/WebRoot/keys/AjxKeys_ta.properties
@@ -272,12 +272,16 @@ list.DoubleClick.description = \u0b87\u0bb0\u0b9f\u0bcd\u0b9f\u0bc8\u0b95\u0bcd 
 list.DoubleClick.sort = 30070
 
 list.Next.display = {ctrl}+ArrowDown
+list.Next.display.mac = {ctrl}+ArrowDown; {ctrl}+{shift}+ArrowDown
 list.Next.keycode = Ctrl+40
+list.Next.keycode.mac = Ctrl+40; Ctrl+Shift+40
 list.Next.description = \u0b85\u0b9f\u0bc1\u0ba4\u0bcd\u0ba4 \u0b89\u0bb0\u0bc1\u0baa\u0bcd\u0baa\u0b9f\u0bbf\u0baf\u0bbf\u0bb2\u0bcd \u0b83\u0baa\u0bcb\u0b95\u0bb8\u0bcd \u0b9a\u0bc6\u0baf\u0bcd\u0baf\u0bb5\u0bc1\u0bae\u0bcd
 list.Next.sort = 30110
 
 list.Previous.display = {ctrl}+ArrowUp
+list.Previous.display.mac = {ctrl}+ArrowUp; {ctrl}+{shift}+ArrowUp
 list.Previous.keycode = Ctrl+38
+list.Previous.keycode.mac = Ctrl+38; Ctrl+Shift+38
 list.Previous.description = \u0bae\u0bc1\u0ba8\u0bcd\u0ba4\u0bc8\u0baf \u0b89\u0bb0\u0bc1\u0baa\u0bcd\u0baa\u0b9f\u0bbf\u0baf\u0bbf\u0bb2\u0bcd \u0b83\u0baa\u0bcb\u0b95\u0bb8\u0bcd \u0b9a\u0bc6\u0baf\u0bcd\u0baf\u0bb5\u0bc1\u0bae\u0bcd
 list.Previous.sort = 30120
 

--- a/WebRoot/keys/AjxKeys_th.properties
+++ b/WebRoot/keys/AjxKeys_th.properties
@@ -272,12 +272,16 @@ list.DoubleClick.description = \u0e04\u0e25\u0e34\u0e01\u0e2a\u0e2d\u0e07\u0e04\
 list.DoubleClick.sort = 30070
 
 list.Next.display = {ctrl}+\u0e25\u0e39\u0e01\u0e28\u0e23\u0e25\u0e07
+list.Next.display.mac = {ctrl}+\u0e25\u0e39\u0e01\u0e28\u0e23\u0e25\u0e07; {ctrl}+{shift}+\u0e25\u0e39\u0e01\u0e28\u0e23\u0e25\u0e07
 list.Next.keycode = Ctrl+40
+list.Next.keycode.mac = Ctrl+40; Ctrl+Shift+40
 list.Next.description = \u0e42\u0e1f\u0e01\u0e31\u0e2a\u0e23\u0e32\u0e22\u0e01\u0e32\u0e23\u0e16\u0e31\u0e14\u0e44\u0e1b
 list.Next.sort = 30110
 
 list.Previous.display = {ctrl}+\u0e25\u0e39\u0e01\u0e28\u0e23\u0e02\u0e36\u0e49\u0e19
+list.Previous.display.mac = {ctrl}+\u0e25\u0e39\u0e01\u0e28\u0e23\u0e02\u0e36\u0e49\u0e19; {ctrl}+{shift}+\u0e25\u0e39\u0e01\u0e28\u0e23\u0e02\u0e36\u0e49\u0e19
 list.Previous.keycode = Ctrl+38
+list.Previous.keycode.mac = Ctrl+38; Ctrl+Shift+38
 list.Previous.description = \u0e42\u0e1f\u0e01\u0e31\u0e2a\u0e23\u0e32\u0e22\u0e01\u0e32\u0e23\u0e01\u0e48\u0e2d\u0e19\u0e2b\u0e19\u0e49\u0e32
 list.Previous.sort = 30120
 

--- a/WebRoot/keys/AjxKeys_tr.properties
+++ b/WebRoot/keys/AjxKeys_tr.properties
@@ -272,12 +272,16 @@ list.DoubleClick.description = \u00c7ift t\u0131kla
 list.DoubleClick.sort = 30070
 
 list.Next.display = {ctrl}+A\u015fa\u011f\u0131 Ok
+list.Next.display.mac = {ctrl}+A\u015fa\u011f\u0131 Ok; {ctrl}+{shift}+A\u015fa\u011f\u0131 Ok
 list.Next.keycode = Ctrl+40
+list.Next.keycode.mac = Ctrl+40; Ctrl+Shift+40
 list.Next.description = Sonraki \u00f6\u011feye odakla
 list.Next.sort = 30110
 
 list.Previous.display = {ctrl}+Yukar\u0131 Ok
+list.Previous.display.mac = {ctrl}+Yukar\u0131 Ok; {ctrl}+{shift}+Yukar\u0131 Ok
 list.Previous.keycode = Ctrl+38
+list.Previous.keycode.mac = Ctrl+38; Ctrl+Shift+38
 list.Previous.description = \u00d6nceki \u00f6\u011feye odakla
 list.Previous.sort = 30120
 

--- a/WebRoot/keys/AjxKeys_uk.properties
+++ b/WebRoot/keys/AjxKeys_uk.properties
@@ -272,12 +272,16 @@ list.DoubleClick.description = \u041f\u043e\u0434\u0432\u0456\u0439\u043d\u0435 
 list.DoubleClick.sort = 30070
 
 list.Next.display = {ctrl}+\u0441\u0442\u0440\u0456\u043b\u043a\u0430 \u0432\u043d\u0438\u0437
+list.Next.display.mac = {ctrl}+\u0441\u0442\u0440\u0456\u043b\u043a\u0430 \u0432\u043d\u0438\u0437; {ctrl}+{shift}+\u0441\u0442\u0440\u0456\u043b\u043a\u0430 \u0432\u043d\u0438\u0437
 list.Next.keycode = Ctrl+40
+list.Next.keycode.mac = Ctrl+40; Ctrl+Shift+40
 list.Next.description = \u0424\u043e\u043a\u0443\u0441 \u043d\u0430 \u043d\u0430\u0441\u0442\u0443\u043f\u043d\u043e\u043c\u0443 \u0435\u043b\u0435\u043c\u0435\u043d\u0442\u0456
 list.Next.sort = 30110
 
 list.Previous.display = {ctrl}+c\u0442\u0440\u0456\u043b\u043a\u0430 \u0432\u0433\u043e\u0440\u0443
+list.Previous.display.mac = {ctrl}+c\u0442\u0440\u0456\u043b\u043a\u0430 \u0432\u0433\u043e\u0440\u0443; {ctrl}+{shift}+c\u0442\u0440\u0456\u043b\u043a\u0430 \u0432\u0433\u043e\u0440\u0443
 list.Previous.keycode = Ctrl+38
+list.Previous.keycode.mac = Ctrl+38; Ctrl+Shift+38
 list.Previous.description = \u0424\u043e\u043a\u0443\u0441 \u043d\u0430 \u043f\u043e\u043f\u0435\u0440\u0435\u0434\u043d\u044c\u043e\u043c\u0443 \u0435\u043b\u0435\u043c\u0435\u043d\u0442\u0456
 list.Previous.sort = 30120
 

--- a/WebRoot/keys/AjxKeys_vi.properties
+++ b/WebRoot/keys/AjxKeys_vi.properties
@@ -272,12 +272,16 @@ list.DoubleClick.description = B\u1ea5m \u0111\u00fap
 list.DoubleClick.sort = 30070
 
 list.Next.display = {ctrl}+ArrowDown
+list.Next.display.mac = {ctrl}+ArrowDown; {ctrl}+{shift}+ArrowDown
 list.Next.keycode = Ctrl+40
+list.Next.keycode.mac = Ctrl+40; Ctrl+Shift+40
 list.Next.description = Ch\u1ecdn m\u1ee5c k\u1ebf ti\u1ebfp
 list.Next.sort = 30110
 
 list.Previous.display = {ctrl}+ArrowUp
+list.Previous.display.mac = {ctrl}+ArrowUp; {ctrl}+{shift}+ArrowUp
 list.Previous.keycode = Ctrl+38
+list.Previous.keycode.mac = Ctrl+38; Ctrl+Shift+38
 list.Previous.description = Ch\u1ecdn m\u1ee5c tr\u01b0\u1edbc
 list.Previous.sort = 30120
 

--- a/WebRoot/keys/AjxKeys_zh_CN.properties
+++ b/WebRoot/keys/AjxKeys_zh_CN.properties
@@ -272,12 +272,16 @@ list.DoubleClick.description = \u53cc\u51fb
 list.DoubleClick.sort = 30070
 
 list.Next.display = {ctrl}+\u4e0b\u7bad\u5934
+list.Next.display.mac = {ctrl}+\u4e0b\u7bad\u5934; {ctrl}+{shift}+\u4e0b\u7bad\u5934
 list.Next.keycode = Ctrl+40
+list.Next.keycode.mac = Ctrl+40; Ctrl+Shift+40
 list.Next.description = \u628a\u5149\u6807\u79fb\u81f3\u4e0b\u4e00\u9879
 list.Next.sort = 30110
 
 list.Previous.display = {ctrl}+\u4e0a\u7bad\u5934
+list.Previous.display.mac = {ctrl}+\u4e0a\u7bad\u5934; {ctrl}+{shift}+\u4e0a\u7bad\u5934
 list.Previous.keycode = Ctrl+38
+list.Previous.keycode.mac = Ctrl+38; Ctrl+Shift+38
 list.Previous.description = \u628a\u5149\u6807\u79fb\u81f3\u4e0a\u4e00\u9879
 list.Previous.sort = 30120
 

--- a/WebRoot/keys/AjxKeys_zh_HK.properties
+++ b/WebRoot/keys/AjxKeys_zh_HK.properties
@@ -272,12 +272,16 @@ list.DoubleClick.description = \u6309\u5169\u4e0b
 list.DoubleClick.sort = 30070
 
 list.Next.display = {ctrl}+\u4e0b\u7bad\u5480
+list.Next.display.mac = {ctrl}+\u4e0b\u7bad\u5480; {ctrl}+{shift}+\u4e0b\u7bad\u5480
 list.Next.keycode = Ctrl+40
+list.Next.keycode.mac = Ctrl+40; Ctrl+Shift+40
 list.Next.description = \u628a\u6e38\u6a19\u79fb\u81f3\u4e0b\u4e00\u9805
 list.Next.sort = 30110
 
 list.Previous.display = {ctrl}+\u4e0a\u7bad\u5480
+list.Previous.display.mac = {ctrl}+\u4e0a\u7bad\u5480; {ctrl}+{shift}+\u4e0a\u7bad\u5480
 list.Previous.keycode = Ctrl+38
+list.Previous.keycode.mac = Ctrl+38; Ctrl+Shift+38
 list.Previous.description = \u628a\u6e38\u6a19\u79fb\u81f3\u4e0a\u4e00\u9805
 list.Previous.sort = 30120
 

--- a/WebRoot/keys/AjxKeys_zh_TW.properties
+++ b/WebRoot/keys/AjxKeys_zh_TW.properties
@@ -272,12 +272,16 @@ list.DoubleClick.description = \u9023\u6309\u5169\u4e0b
 list.DoubleClick.sort = 30070
 
 list.Next.display = {ctrl}+\u5411\u4e0b\u9375
+list.Next.display.mac = {ctrl}+\u5411\u4e0b\u9375; {ctrl}+{shift}+\u5411\u4e0b\u9375
 list.Next.keycode = Ctrl+40
+list.Next.keycode.mac = Ctrl+40; Ctrl+Shift+40
 list.Next.description = \u805a\u7126\u4e0b\u4e00\u9805
 list.Next.sort = 30110
 
 list.Previous.display = {ctrl}+\u5411\u4e0a\u9375
+list.Previous.display.mac = {ctrl}+\u5411\u4e0a\u9375; {ctrl}+{shift}+\u5411\u4e0a\u9375
 list.Previous.keycode = Ctrl+38
+list.Previous.keycode.mac = Ctrl+38; Ctrl+Shift+38
 list.Previous.description = \u805a\u7126\u4e0a\u4e00\u9805
 list.Previous.sort = 30120
 


### PR DESCRIPTION
Added new shortcuts To move focus on previous/next item in list for MacOS.

- Existing CTRL + UP/DOWN Arrow key shortcuts are not working on MacOS To Move focus on previous or next item as this shortcuts have been used as MacOs System shortcuts.
- Hence, Added CTRL+SHIFT+UP/DOWN Arrow key shortcuts for Move focus to previous or next item in the list for Mac OS.
- Additionally, Fixed NVDA annoucement when list item is selected by user. Previously, NVDA was not announce as selected when user navigate to checked item.