### PR TITLE
ZCS-12677: added an ability to ignore files defined in manifest.xml

### DIFF
--- a/src/com/zimbra/webClient/servlet/SkinResources.java
+++ b/src/com/zimbra/webClient/servlet/SkinResources.java
@@ -1540,6 +1540,7 @@ public class SkinResources
 		private static final String E_COMMON = "common";
 		private static final String E_STANDARD = "standard";
 		private static final String E_ADVANCED = "advanced";
+		private static final String E_IGNORE_SUFFIX = "Ignore";
 
 		private static final Pattern RE_TOKEN = Pattern.compile("@.+?@");
 		private static final Pattern RE_SKIN_METHOD = Pattern.compile("@(\\w+)\\((.*?)\\)@");
@@ -2241,6 +2242,7 @@ public class SkinResources
 				root = docElement;
 			}
 			addFiles(root, ename, baseDir, list);
+			removeFiles(root, (ename + E_IGNORE_SUFFIX), baseDir, list);
 		}
 
 		private void addFiles(Element root, String ename,
@@ -2254,6 +2256,30 @@ public class SkinResources
 					String filename = getChildText(fileEl);
 					File file = new File(baseDir, filename);
 					list.add(file);
+					fileEl = getNextSiblingElement(fileEl, E_FILE);
+				}
+			}
+		}
+
+		private void removeFiles(Element root, String ename,
+							  File baseDir, List<File> list) {
+			if (root == null) return;
+
+			Element element = getFirstChildElement(root, ename);
+			if (element != null) {
+				Element fileEl = getFirstChildElement(element, E_FILE);
+				while (fileEl != null) {
+					String filename = getChildText(fileEl);
+					File file = new File(baseDir, filename);
+					for (File f : list) {
+						if (f.getAbsolutePath().equals(file.getAbsolutePath())) {
+							list.remove(f);
+							if (ZimbraLog.webclient.isDebugEnabled()) {
+								ZimbraLog.webclient.debug("DEBUG: ignored file " + file.getAbsolutePath());
+							}
+							break;
+						}
+					}
 					fileEl = getNextSiblingElement(fileEl, E_FILE);
 				}
 			}


### PR DESCRIPTION
Add ability to ignore files specified in `manifest.xml` of a skin.

When css file(s) in a skin is requested, the following http request is sent.
(for example)
* `https://host/css/images,common,dwt,msgview,login,zm,spellcheck,skin.css?v=220916072527&debug=false&skin=harmony&locale=en_US`
* `https://host/css/common,login,images,skin.css?client=standard&skin=harmony&v=220916072527`

Regardless of `client` parameter, css files defined in `common / css` section (element) are always included in a response.
When `client=advanced` is specified, css file(s) defined in `advanced / css` is added to the response.
When `client=standard` is specified, the file(s) in `standard / css` is added.

Now we are adding `print / css` section for print message/contact/appointment/task. The request will be
`https://host/css/zhtml,skin.css?client=print&skin=harmony&v=220916072527&debug=`. 
In the page, the css files defined in `common / css` should **NOT** be loaded to keep the current styles. We just want to add `print.css`.
Reference: https://github.com/Zimbra/zm-web-client/pull/788

The PR is adding a logic to address `xxxIgnore` element. If it is described in manifest.xml, a file specified in `common` section is canceled.
In the manifest.xml below, for example, `print / cssIgnore` is defined. When `client=print` is specified in the request url, `<file>../_base/base3/print.css</file>` is loaded, but `<file>../_base/base3/skin.css</file> and <file>skin.css</file>` specified in `common` are not loaded.

```
	<common>
		<substitutions>
			<file>../_base/base3/skin.properties</file>
			<file>skin.properties</file>
		</substitutions>
		<css>
			<file>../_base/base3/skin.css</file>
			<file>skin.css</file>
		</css>
	</common>
	<advanced>
		<script>
			<file>../_base/base3/ZmSkin.js</file>
		</script>
		<html>
			<file>../_base/base3/skin.html</file>
			<file>../_base/base3/splash.html</file>
		</html>
	</advanced>
	<standard>
		<css>
			<file>../../css/zhtml.css</file>
			<file>../_base/base3/zhtml.css</file>
		</css>
	</standard>
	<print>
		<css>
			<file>../_base/base3/print.css</file>
		</css>
		<cssIgnore>
			<file>../_base/base3/skin.css</file>
			<file>skin.css</file>
		</cssIgnore>
	</print>
</skin>
```

In SkinResources.java, files defined in `common / css` and `print / css` are added to the `list` at line 2244. After that, `xxxIgnore` is checked at line 2245. The structure / logic of `removeFiles (Element root, String ename, File baseDir, List<File> list)` is based on `addFiles` (lines 2248-2262).
It gets a value of `<file>` element in `xxxIgnore`, compares path of a File in `list`, and removes it from `list` if the path matches the value of the element.

manifest.xml is parsed sequentially. `common` is checked at line 2239 and then `advance, standard, or print` is checked at 2244. It is difficult to add the logic of checking `cssIgnore` to `addFiles`. Then `removeFiles` is called after all css files are added to `list`.