### PR TITLE
ZBUG-3437: added parameter to restore checkbox status

### DIFF
--- a/WebRoot/js/ajax/dwt/widgets/DwtListView.js
+++ b/WebRoot/js/ajax/dwt/widgets/DwtListView.js
@@ -704,7 +704,7 @@ function(item, skipNotify, skipAlternation) {
 };
 
 DwtListView.prototype.redrawItem =
-function(item) {
+function(item, restoreState) {
     var odiv = this._getElFromItem(item);
     if (odiv) {
 		var className = odiv.className;
@@ -714,7 +714,11 @@ function(item) {
 		// preserve selection
 		if (this._selectedItems.contains(odiv)) {
 			this._selectedItems.remove(odiv);
-			this.selectItem(item);
+			if (restoreState) {
+				this.setMultiSelection(ndiv, false);
+			} else {
+				this.selectItem(item);
+			}
 		}
 
         //update the _kbAnchor as the old element has been swapped with the new element


### PR DESCRIPTION
**Issue:**
* see https://github.com/Zimbra/zm-web-client/pull/833

**Change:**
adding `restoreState` parameter to `DwtListView.prototype.redrawItem` so that the `selected` status of the item can be kept (restored).

