### PR TITLE
ZBUG-3322: hyperlinks over images not working issue 

### DIFF
--- a/WebRoot/js/ajax/dwt/widgets/DwtControl.js
+++ b/WebRoot/js/ajax/dwt/widgets/DwtControl.js
@@ -3605,13 +3605,16 @@ function(ev, eventType, obj, mouseEv) {
 
 	// By default, we halt event processing. The default can be overridden here through
 	// the use of setEventPropagation(). A listener may also change the event props when called.
-	var tn = mouseEv.target.tagName && mouseEv.target.tagName.toLowerCase();
-	var propagate = obj._propagateEvent[eventType] || (tn === "input" || tn === "textarea" || tn === "a" || tn === "label" || tn === "select");
+	var target = mouseEv.target;
+	var tn = target.tagName;
+	var parentTn = target.parentElement && target.parentElement.tagName;
+	var containerTags = ["A", "LABEL"];
+	var propagate = obj._propagateEvent[eventType] || (tn === "INPUT" || tn === "TEXTAREA" || tn === "SELECT" || containerTags.includes(tn));
 	//todo - not sure if _stopPropagation and _dontCallPreventDefault should not the the SAME. Since if you stop propagation and dontCallPreventDefault,
 	//it DOES allow selection (or context menu, etc, any default browser stuff). But if you allow to propagate, this might be overriden by a DOM element
 	//higher up, which might not be what we want. Very confusing.
 	mouseEv._stopPropagation = !propagate;
-	mouseEv._dontCallPreventDefault = propagate;
+	mouseEv._dontCallPreventDefault = containerTags.includes(parentTn) || propagate;
 	mouseEv._returnValue = propagate;
 
 	// notify global listeners


### PR DESCRIPTION
1. The DwtControl click event was adding preventDefault on the almost all the elements except the ones provided in the condition which include an achor tag as well. However it didnt have the logic to check whether the element is a child of the anchor tag or such tags which should not prevent the events. Added the logic which also fixes issue ZBUG-3322.

2. Also observed that there was unnecessary conversion of tagNames string to lowercase, hence removed that logic. The tagNames always returns capital case names. I tested it on chrome, firefox and safari. Since the code executes at almost every DOM event, I though we should avoid unnecessary operations.

Automation workflow - https://app.circleci.com/pipelines/github/ZimbraOS/zm-frontend-automation/964/workflows/178e671e-4595-4f92-98a3-06745d002623 
(The failures are from master branch)
