### PR TITLE
ZCS-14071: added account.CODE_EXPIRED

### DIFF
--- a/WebRoot/messages/ZMsg.properties
+++ b/WebRoot/messages/ZMsg.properties
@@ -25,6 +25,7 @@ CSFE_SVC_ERROR = A network service error has occurred.
 
 account.AUTH_FAILED = The username or password is incorrect. Verify that CAPS LOCK is not on, and then retype the current username and password.
 account.TWO_FACTOR_AUTH_FAILED = The one-time code used is incorrect. Please try again.
+account.CODE_EXPIRED = The one-time code used is incorrect. Please try again.
 account.CHANGE_PASSWORD = Your password is no longer valid. Please choose a new password.
 account.INVALID_PASSWORD = You have entered an invalid password.
 account.INVALID_PREF_NAME = Invalid preference name.


### PR DESCRIPTION
Adding a message for `account.CODE_EXPIRED` exception. It is used when a TFA code sent by email has been expired.
The message is the same as `account.TWO_FACTOR_AUTH_FAILED`. Too much information should not be shown during login process.

Related PRs:
* https://github.com/Zimbra/zm-web-client/pull/848
* https://github.com/Zimbra/zm-taglib/pull/52
* https://github.com/Zimbra/zm-mailbox/pull/1541