### PR TITLE
ZBUG-4918: Fixed classic UI not loading with chrome 137 issue

### DIFF
--- a/WebRoot/js/ajax/soap/AjxSoapDoc.js
+++ b/WebRoot/js/ajax/soap/AjxSoapDoc.js
@@ -58,7 +58,7 @@ function(method, namespace, namespaceId, soapURI) {
 		soapURI = AjxSoapDoc._SOAP_URI;
 	sd._soapURI = soapURI;
 
-	var useNS = d.createElementNS && !AjxEnv.isSafari;
+	var useNS = d.createElementNS;
 	var envEl = useNS ?  d.createElementNS(soapURI, "soap:Envelope") : d.createElement("soap:Envelope");
 	if (!useNS) envEl.setAttribute("xmlns:soap", soapURI);
 
@@ -169,7 +169,7 @@ AjxSoapDoc.prototype.set =
 function(name, value, parent, namespace) {
 	var	doc = this.getDoc();
 
-	var useNS = doc.createElementNS && !AjxEnv.isSafari;
+	var useNS = doc.createElementNS;
 
 	var	p = name
 		? (namespace && useNS ? doc.createElementNS(namespace, name) : doc.createElement(name))
@@ -226,7 +226,7 @@ function() {
 	if (header != null) {
 		throw new AjxSoapException("SOAP header already exists", AjxSoapException.ELEMENT_EXISTS, "AjxSoapDoc.prototype.createHeaderElement");
 	}
-	var useNS = d.createElementNS && !AjxEnv.isSafari;
+	var useNS = d.createElementNS;
 	header = useNS ? d.createElementNS(this._soapURI, "soap:Header") : d.createElement("soap:Header")
 	envEl.insertBefore(header, envEl.firstChild);
 	return header;


### PR DESCRIPTION
Root cause:

1. In the previous implementation if `userAgent` string output contains safari, then we are skipping creating soap document element with default namespace. And istead the namespace is added later using `setAttribute` method.
2. In chrome beta version 137, as per https://issues.chromium.org/issues/415370691#comment16, the namespace attribute is getting removed if it is not created with `createElementNS` method which adds default namespace.
3. Although this behaviour is now fixed from chrome side, we have observed that `createElementNS` is now supported by all browsers - https://developer.mozilla.org/en-US/docs/Web/API/Document/createElementNS. (note: we are not using options argument anywhere)

Solution: Since `createElementNS` is supported by almost all the browsers now including safari. We should avoid using setting namespace explicitly and add it using createElementNS while creating element. This will also avoid similar issues in longer run.

Testing on Chrome beta:

<img width="1705" alt="image" src="https://github.com/user-attachments/assets/30144cc9-0126-4164-982d-05ce466ed154" />

Automation result: https://app.circleci.com/pipelines/github/Zimbra/zm-frontend-automation/2932/workflows/7cfbfd55-3fb1-4d8f-8483-6dc542c9550c (Passing)
