### PR TITLE
ZCS-17472:update Java ant-1.6.5.jar for security and compatibility reasons

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -5,7 +5,7 @@
  <info organisation="zimbra" module="zm-ajax" status="integration">
  </info>
  <dependencies>
-	<dependency org="ant" name="ant" rev="1.6.5"/>
+	<dependency org="org.apache.ant" name="ant" rev="1.10.15"/>
 	<dependency org="org.json" name="json" rev="20070829"/>
 	<dependency org="javax.servlet" name="javax.servlet-api" rev="3.1.0"/>
 	<dependency org="commons-cli" name="commons-cli" rev="1.2" />


### PR DESCRIPTION
Code changes to update Current Ant version which is from **ant-1.6.5.jar** to **ant-1.10.15.jar**
as per official-release notes -> https://ant.apache.org/bindownload.cgi