### PR TITLE
ZBUG-4533: [Classic UI] Fix Catalan weekday short abbreviations in AjxMsg_ca.properties

### DIFF
--- a/WebRoot/messages/AjxMsg_ca.properties
+++ b/WebRoot/messages/AjxMsg_ca.properties
@@ -133,13 +133,13 @@ _prev = Anterior
 _finish = Finalitza
 _close = Tanca
 
-weekdaySunShort = D
-weekdayMonShort = L
-weekdayTueShort = J
-weekdayWedShort = T
-weekdayThuShort = J
-weekdayFriShort = V
-weekdaySatShort = D
+weekdaySunShort = Dg
+weekdayMonShort = Dl
+weekdayTueShort = Dm
+weekdayWedShort = Dc
+weekdayThuShort = Dj
+weekdayFriShort = Dv
+weekdaySatShort = Ds
 
 monthJanShort = G
 monthFebShort = V


### PR DESCRIPTION
Replace single-character (mixed Spanish/English) weekday abbreviations with the correct 2-character IEC standard Catalan abbreviations:

  weekdaySunShort: D  → Dg (Diumenge)
  weekdayMonShort: L  → Dl (Dilluns)
  weekdayTueShort: J  → Dm (Dimarts)
  weekdayWedShort: T  → Dc (Dimecres)
  weekdayThuShort: J  → Dj (Dijous)
  weekdayFriShort: V  → Dv (Divendres)
  weekdaySatShort: D  → Ds (Dissabte)

The previous values were single characters borrowed from Spanish (L=Lunes, J=Jueves/Juernes, V=Viernes) and English, causing duplicate letters (both Sunday and Saturday showed 'D', both Tuesday and Thursday showed 'J').